### PR TITLE
Fehlermeldung, Symbol('key'), __LOG.info(), Uint32Arr, Date, Symbol 2x

### DIFF
--- a/misc/OS2/lib/test.assert.js
+++ b/misc/OS2/lib/test.assert.js
@@ -31,9 +31,9 @@ function AssertionFailed(whatFailed, msg, thisArg, ...params) {
     } else if ((typeof msg) === 'function') {
         const __TEXT = msg.call(__THIS, ...params);
 
-        this.message = ((__TEXT === undefined) ? __TEXT : __LOG.info(__TEXT, false, true));
+        this.message = String(__TEXT);
     } else {
-        this.message = __LOG.info(msg, ((typeof msg) !== 'string'), true);
+        this.message = String(msg);
     }
 
     if (whatFailed) {

--- a/misc/OS2/lib/util.object.js
+++ b/misc/OS2/lib/util.object.js
@@ -84,8 +84,10 @@ function getObjInfo(obj, keyStrings, longForm, stepIn) {
     const __LENGTH = ((obj != undefined) ? ((__TYPEOF === 'object') ? Object.entries(obj) : obj).length : obj);
     const __STRDELIM1 = (keyStrings ? "'" : '"');
     const __STRDELIM2 = (keyStrings ? "'" : '"');
-    const __NUMDELIM1 = (keyStrings ? "" : '<');
-    const __NUMDELIM2 = (keyStrings ? "" : '>');
+    const __NUMDELIM1 = (keyStrings ? "" : '‹');
+    const __NUMDELIM2 = (keyStrings ? "" : '›');
+    const __SYMDELIM1 = (keyStrings ? "" : '(');
+    const __SYMDELIM2 = (keyStrings ? "" : ')');
     const __SPACE = (keyStrings ? "" : ' ');
     const __ARRDELIM = ',' + __SPACE;
     const __ARRDELIM1 = '[';
@@ -94,42 +96,48 @@ function getObjInfo(obj, keyStrings, longForm, stepIn) {
     const __OBJDELIM = ',' + __SPACE;
     const __OBJDELIM1 = '{';
     const __OBJDELIM2 = '}';
-    const __LENSTR = ((__LENGTH !== undefined) ? __ARRDELIM1 + __LENGTH + __ARRDELIM2 : "")
-    const __VALUESTR = String(obj);
+    const __LENSTR = (__LENGTH ? __ARRDELIM1 + __LENGTH + __ARRDELIM2 : "");
+    const __VALUESTR = ((__TYPEOF === 'symbol') ? __LOG.info(getValue(Symbol.keyFor(obj), ""), false) : String(obj));
     let typeStr = __TYPEOF;
     let valueStr = __VALUESTR;
 
     switch (__TYPEOF) {
-    case 'undefined' : break;
-    case 'string'    : typeStr = 'String';
-                       valueStr = __STRDELIM1 + valueStr + __STRDELIM2;
-                       break;
-    case 'boolean'   : typeStr = 'Boolean';
-                       break;
-    case 'number'    : if (Number.isInteger(obj)) {
-                           typeStr = 'Integer';
-                       } else {
-                           typeStr = 'Number';
-                           valueStr = __NUMDELIM1 + valueStr + __NUMDELIM2;
-                       }
-                       break;
-    case 'function'  : break;
-    case 'object'    : if (Array.isArray(obj)) {
-                           const __VALSTR = (__LENGTH ? obj.map(item => getValStr(item, false, stepIn, longForm, stepIn)).join(__ARRDELIM) : "");
+    case 'undefined'  : break;
+    case 'string'     : typeStr = 'String';
+                        valueStr = __STRDELIM1 + valueStr + __STRDELIM2;
+                        break;
+    case 'boolean'    : typeStr = 'Boolean';
+                        break;
+    case 'number'     : if (Number.isInteger(obj)) {
+                            typeStr = 'Integer';
+                        } else {
+                            typeStr = 'Number';
+                            valueStr = __NUMDELIM1 + valueStr + __NUMDELIM2;
+                        }
+                        break;
+    case 'function'   : longForm = false;
+                        valueStr = valueStr.substr(typeStr.length);
+                        break;
+    case 'symbol'     : typeStr = 'Symbol';
+                        longForm = false;
+                        valueStr = __SYMDELIM1 + valueStr + __SYMDELIM2;
+                        break;
+    case 'object'     : if (Array.isArray(obj)) {
+                            const __VALSTR = (__LENGTH ? obj.map(item => getValStr(item, false, stepIn, longForm, stepIn)).join(__ARRDELIM) : "");
 
-                           typeStr = 'Array';
-                           valueStr = __ARRDELIM1 + (__LENGTH ? __SPACE + __VALSTR + __SPACE : "") + __ARRDELIM2;
-                       } else {
-                           const __CLASS = getClass(obj);
-                           const __CLASSNAME = (__CLASS ? getClassName(obj) : "");
-                           const __VALSTR = (__LENGTH ? Object.values(Object.map(obj, (value, key) => (getValStr(key, true) + __OBJSETTER
+                            typeStr = 'Array';
+                            valueStr = __ARRDELIM1 + (__LENGTH ? __SPACE + __VALSTR + __SPACE : "") + __ARRDELIM2;
+                        } else {
+                            const __CLASS = getClass(obj);
+                            const __CLASSNAME = (__CLASS ? getClassName(obj) : "");
+                            const __VALSTR = (__LENGTH ? Object.values(Object.map(obj, (value, key) => (getValStr(key, true) + __OBJSETTER
                                             + getValStr(value, false, stepIn, longForm, stepIn)))).join(__OBJDELIM) : "");
 
-                           typeStr = (__CLASSNAME ? __CLASSNAME : typeStr);
-                           valueStr = (__CLASSNAME ? __CLASSNAME + __SPACE : "") + __OBJDELIM1 + (__LENGTH ? __SPACE + __VALSTR + __SPACE : "") + __OBJDELIM2;
-                       }
-                       break;
-    default :          break;
+                            typeStr = (__CLASSNAME ? __CLASSNAME : typeStr);
+                            valueStr = __OBJDELIM1 + (__LENGTH ? __SPACE + __VALSTR + __SPACE : "") + __OBJDELIM2;
+                        }
+                        break;
+    default :           break;
     }
 
     if (obj == undefined) {
@@ -141,12 +149,12 @@ function getObjInfo(obj, keyStrings, longForm, stepIn) {
     }
 
     return [
-               typeStr + (longForm ? __LENSTR : ""),
-               valueStr,
-               __TYPEOF,
-               __VALUEOF,
-               __LENGTH
-           ];
+                typeStr + (longForm ? __LENSTR : ""),
+                valueStr,
+                __TYPEOF,
+                __VALUEOF,
+                __LENGTH
+            ];
 }
 
 // Liefert detaillierte Angaben zu einem Objekt aller Art, also Object, Array, Function, String, etc.

--- a/misc/OS2/lib/util.store.js
+++ b/misc/OS2/lib/util.store.js
@@ -55,17 +55,17 @@ if (__GMWRITE) {
 // value: Zu speichernder String/Integer/Boolean-Wert
 // return Promise auf ein Objekt, das 'name' und 'value' der Operation enthaelt
 function storeValue(name, value) {
-    __LOG[5](name + " >> " + value);
+    __LOG[5](name + " >> " + __LOG.info(value, true, true));
 
     return __SETVALUE(name, value).then(voidValue => {
-            __LOG[6]("OK " + name + " >> " + value);
+            __LOG[6]('OK', name, '>>', __LOG.info(value, true, true));
 
             return Promise.resolve({
                     'name'  : name,
                     'value' : value
                 });
         }, ex => {
-            __LOG[1](name + ": " + ex.message);
+            __LOG[1](name + ':', ex.message);
 
             return Promise.reject(ex);
         });
@@ -77,11 +77,11 @@ function storeValue(name, value) {
 // return Promise fuer den String/Integer/Boolean-Wert, der unter dem Namen gespeichert war
 function summonValue(name, defValue = undefined) {
     return __GETVALUE(name, defValue).then(value => {
-            __LOG[5](name + " << " + value);
+            __LOG[5](name, '<<', __LOG.info(value, true, true));
 
             return Promise.resolve(value);
         }, ex => {
-            __LOG[1](name + ": " + ex.message);
+            __LOG[1](name + ':', ex.message);
 
             return Promise.reject(ex);
         });
@@ -94,11 +94,11 @@ function discardValue(name) {
     __LOG[5]("DELETE " + __LOG.info(name, false));
 
     return __DELETEVALUE(name).then(value => {
-            __LOG[5]("OK DELETE " + name);
+            __LOG[5]('OK', 'DELETE', name);
 
             return Promise.resolve(value);
         }, ex => {
-            __LOG[1](name + ": " + ex.message);
+            __LOG[1](name + ':', ex.message);
 
             return Promise.reject(ex);
         });
@@ -112,7 +112,7 @@ function keyValues() {
 
             return Promise.resolve(keys);
         }, ex => {
-            __LOG[1]("KEYS: " + ex.message);
+            __LOG[1]("KEYS:", ex.message);
 
             return Promise.reject(ex);
         });
@@ -138,8 +138,8 @@ function deserialize(name, defValue = undefined) {
                 try {
                     return JSON.parse(stream);
                 } catch (ex) {
-                    __LOG[1](__LOG.info(name, false) + " << " + __LOG.info(stream, true, true));
-                    ex.message += ": " + name + " == " + stream;
+                    __LOG[1](__LOG.info(name, false), '<<', __LOG.info(stream, true, true));
+                    ex.message += ": " + __LOG.info(name, false) + " : " + __LOG.info(stream);
                     throw ex;
                 }
             } else {

--- a/misc/OS2/test/util.store.test.js
+++ b/misc/OS2/test/util.store.test.js
@@ -34,9 +34,9 @@
             'Array3'    : [ 'UnitTestA',    [ String(1), undefined, new Boolean(true) ],                        '["1",null,true]' ],
             'Object'    : [ 'UnitTestO',    { eins : 1, zwei : 2, fuenf : 5 },                                  '{"eins":1,"zwei":2,"fuenf":5}' ],
             'Object2'   : [ 'UnitTestO',    { 'c': { i : true, a : null }, a : { b : { c : [ 2, 47.11 ] } } },  '{"c":{"i":true,"a":null},"a":{"b":{"c":[2,47.11]}}}' ],
-            'Object3'   : [ 'UnitTestO',    new AssertionFailed(new Boolean(true), "Fehler"),                   '{"message":"\'Fehler\' (true)"}' ],
-            'Undef'     : [ 'UnitTestU',    undefined,                                                          undefined ],
-            'Null'      : [ 'UnitTestN',    null,                                                               'null' ],
+            'Object3'   : [ 'UnitTestO',    new AssertionFailed(new Boolean(true), "Fehler"),                   '{"message":"Fehler (true)"}' ],
+            'Undef'     : [ 'UnitTestUnd',  undefined,                                                          undefined ],
+            'Null'      : [ 'UnitTestNul',  null,                                                               'null' ],
             'NaN'       : [ 'UnitTestNaN',  Number.NaN,                                                         String(Number.NaN) ],  // TODO: 'null'?
             'PosInf'    : [ 'UnitTestInf',  Number.POSITIVE_INFINITY,                                           String(Number.POSITIVE_INFINITY) ],
             'NegInf'    : [ 'UnitTestInf',  Number.NEGATIVE_INFINITY,                                           String(Number.NEGATIVE_INFINITY) ],
@@ -45,10 +45,14 @@
             'MinInt'    : [ 'UnitTestMin',  Number.MIN_SAFE_INTEGER,                                            String(Number.MIN_SAFE_INTEGER) ],
             'MaxInt'    : [ 'UnitTestMax',  Number.MAX_SAFE_INTEGER,                                            String(Number.MAX_SAFE_INTEGER) ],
             'Epsilon'   : [ 'UnitTestInf',  Number.EPSILON,                                                     String(Number.EPSILON) ],
-            'Function'  : [ 'UnitTestP',    function(x) { return x * x; },                                      undefined ],
-            'Default'   : [ 'UnitTestD',    undefined,                                                          undefined,              __ERROR ],
-            'Default2'  : [ 'UnitTestD',    null,                                                               'null',                 __ERROR ],
-            'Default3'  : [ 'UnitTestD',    "",                                                                 '""',                   __ERROR ]
+            'Uint32Arr' : [ 'UnitTestU',    new Uint32Array([42]),                                              '{"0":42}' ],
+            'Date'      : [ 'UnitTestD',    new Date(Date.UTC(2006, 0, 2, 15, 4, 5)),                           '"2006-01-02T15:04:05.000Z"' ],
+            'Symbol'    : [ 'UnitTestY',    Symbol(),                                                           undefined,              __ERROR ],
+            'Symbol2'   : [ 'UnitTestY',    Symbol.for('key'),                                                  undefined,              __ERROR ],
+            'Function'  : [ 'UnitTestP',    function(x) { return x * x; },                                      undefined,              __ERROR ],
+            'Default'   : [ 'UnitTestDef',  undefined,                                                          undefined,              __ERROR ],
+            'Default2'  : [ 'UnitTestDef',  null,                                                               'null',                 __ERROR ],
+            'Default3'  : [ 'UnitTestDef',  "",                                                                 '""',                   __ERROR ]
         };
 
     // Komponenten der Testreihen (sto/ser x ent/sum/des):
@@ -279,6 +283,50 @@
                                                 return ASSERT_EQUAL(__RET, __VAL, "Epsilon falsch gespeichert");
                                             });
                                     },
+            'storeValueUint32Arr' : function() {
+                                        const [ __NAME, __VAL ] = __TESTDATA['Uint32Arr'];
+
+                                        return callPromiseChain(storeValue(__NAME, __VAL), entry => {
+                                                const __NAM = entry.name;
+                                                const __RET = entry.value;
+
+                                                ASSERT_EQUAL(__NAM, __NAME, "Falscher Speicherort");
+                                                return ASSERT_EQUAL(__RET, __VAL, "Uint32Array falsch gespeichert");
+                                            });
+                                    },
+            'storeValueDate'      : function() {
+                                        const [ __NAME, __VAL ] = __TESTDATA['Date'];
+
+                                        return callPromiseChain(storeValue(__NAME, __VAL), entry => {
+                                                const __NAM = entry.name;
+                                                const __RET = entry.value;
+
+                                                ASSERT_EQUAL(__NAM, __NAME, "Falscher Speicherort");
+                                                return ASSERT_EQUAL(__RET, __VAL, "Date falsch gespeichert");
+                                            });
+                                    },
+            'storeValueSymbol'    : function() {
+                                        const [ __NAME, __VAL ] = __TESTDATA['Symbol'];
+
+                                        return callPromiseChain(storeValue(__NAME, __VAL), entry => {
+                                                const __NAM = entry.name;
+                                                const __RET = entry.value;
+
+                                                ASSERT_EQUAL(__NAM, __NAME, "Falscher Speicherort");
+                                                return ASSERT_EQUAL(__RET, __VAL, "Symbol falsch gespeichert");
+                                            });
+                                    },
+            'storeValueSymbol2'   : function() {
+                                        const [ __NAME, __VAL ] = __TESTDATA['Symbol2'];
+
+                                        return callPromiseChain(storeValue(__NAME, __VAL), entry => {
+                                                const __NAM = entry.name;
+                                                const __RET = entry.value;
+
+                                                ASSERT_EQUAL(__NAM, __NAME, "Falscher Speicherort");
+                                                return ASSERT_EQUAL(__RET, __VAL, "Symbol falsch gespeichert");
+                                            });
+                                    },
             'storeValueFunction'  : function() {
                                         const [ __NAME, __VAL ] = __TESTDATA['Function'];
 
@@ -468,6 +516,42 @@
                                                 const __RET = value;
 
                                                 return ASSERT_EQUAL(__RET, __VAL, "Epsilon falsch geladen");
+                                            });
+                                    },
+            'summonValueUint32Arr': function() {
+                                        const [ __NAME, __VAL ] = __TESTDATA['Uint32Arr'];
+
+                                        return callPromiseChain(storeValue(__NAME, __VAL), entry => summonValue(entry.name, __ERROR), value => {
+                                                const __RET = value;
+
+                                                return ASSERT_EQUAL(__RET, __VAL, "Uint32Array falsch geladen");
+                                            });
+                                    },
+            'summonValueDate'     : function() {
+                                        const [ __NAME, __VAL ] = __TESTDATA['Date'];
+
+                                        return callPromiseChain(storeValue(__NAME, __VAL), entry => summonValue(entry.name, __ERROR), value => {
+                                                const __RET = value;
+
+                                                return ASSERT_EQUAL(__RET, __VAL, "Date falsch geladen");
+                                            });
+                                    },
+            'summonValueSymbol'   : function() {  // NOTE Keine Speicherung von Symbol
+                                        const [ __NAME, __VAL, , __ERR ] = __TESTDATA['Symbol'];
+
+                                        return callPromiseChain(storeValue(__NAME, __VAL), entry => summonValue(entry.name, __ERR), value => {
+                                                const __RET = value;
+
+                                                return ASSERT_EQUAL(__RET, __ERR, "Symbol falsch geladen");
+                                            });
+                                    },
+            'summonValueSymbol2'  : function() {  // NOTE Keine Speicherung von Symbol
+                                        const [ __NAME, __VAL, , __ERR ] = __TESTDATA['Symbol2'];
+
+                                        return callPromiseChain(storeValue(__NAME, __VAL), entry => summonValue(entry.name, __ERR), value => {
+                                                const __RET = value;
+
+                                                return ASSERT_EQUAL(__RET, __ERR, "Symbol falsch geladen");
                                             });
                                     },
             'summonValueFunction' : function() {  // NOTE Keine Speicherung von Function
@@ -686,8 +770,44 @@
                                                 return ASSERT_EQUAL(__RET, __EXP, "Epsilon falsch gespeichert");
                                             });
                                     },
+            'serializeUint32Arr'  : function() {
+                                        const [ __NAME, __VAL, __EXP ] = __TESTDATA['Uint32Arr'];
+
+                                        return callPromiseChain(serialize(__NAME, __VAL), entry => summonValue(entry.name, __ERROR), value => {
+                                                const __RET = value;
+
+                                                return ASSERT_EQUAL(__RET, __EXP, "Uint32Array falsch gespeichert");
+                                            });
+                                    },
+            'serializeDate'       : function() {
+                                        const [ __NAME, __VAL, __EXP ] = __TESTDATA['Date'];
+
+                                        return callPromiseChain(serialize(__NAME, __VAL), entry => summonValue(entry.name, __ERROR), value => {
+                                                const __RET = value;
+
+                                                return ASSERT_EQUAL(__RET, __EXP, "Date falsch gespeichert");
+                                            });
+                                    },
+            'serializeSymbol'     : function() {  // NOTE Keine Speicherung von Symbol
+                                        const [ __NAME, __VAL, , __ERR ] = __TESTDATA['Symbol'];
+
+                                        return callPromiseChain(serialize(__NAME, __VAL), entry => summonValue(entry.name, __ERR), value => {
+                                                const __RET = value;
+
+                                                return ASSERT_EQUAL(__RET, __ERR, "Symbol falsch gespeichert");
+                                            });
+                                    },
+            'serializeSymbol2'    : function() {  // NOTE Keine Speicherung von Symbol
+                                        const [ __NAME, __VAL, , __ERR ] = __TESTDATA['Symbol2'];
+
+                                        return callPromiseChain(serialize(__NAME, __VAL), entry => summonValue(entry.name, __ERR), value => {
+                                                const __RET = value;
+
+                                                return ASSERT_EQUAL(__RET, __ERR, "Symbol falsch gespeichert");
+                                            });
+                                    },
             'serializeFunction'   : function() {  // NOTE Keine Speicherung von Function
-                                        const [ __NAME, __VAL, __EXP, __ERR ] = __TESTDATA['Function'];
+                                        const [ __NAME, __VAL, , __ERR ] = __TESTDATA['Function'];
 
                                         return callPromiseChain(serialize(__NAME, __VAL), entry => summonValue(entry.name, __ERR), value => {
                                                 const __RET = value;
@@ -942,6 +1062,50 @@
                                                 return ASSERT_EQUAL(__RET, __EXP, "Epsilon falsch gespeichert");
                                             });
                                     },
+            'serialize2Uint32Arr' : function() {
+                                        const [ __NAME, __VAL, __EXP ] = __TESTDATA['Uint32Arr'];
+
+                                        return callPromiseChain(serialize(__NAME, __VAL), entry => {
+                                                const __NAM = entry.name;
+                                                const __RET = entry.value;
+
+                                                ASSERT_EQUAL(__NAM, __NAME, "Falscher Speicherort");
+                                                return ASSERT_EQUAL(__RET, __EXP, "Uint32Array falsch gespeichert");
+                                            });
+                                    },
+            'serialize2Date'      : function() {
+                                        const [ __NAME, __VAL, __EXP ] = __TESTDATA['Date'];
+
+                                        return callPromiseChain(serialize(__NAME, __VAL), entry => {
+                                                const __NAM = entry.name;
+                                                const __RET = entry.value;
+
+                                                ASSERT_EQUAL(__NAM, __NAME, "Falscher Speicherort");
+                                                return ASSERT_EQUAL(__RET, __EXP, "Date falsch gespeichert");
+                                            });
+                                    },
+            'serialize2Symbol'    : function() {  // NOTE Keine Speicherung von Symbol
+                                        const [ __NAME, __VAL, __EXP ] = __TESTDATA['Symbol'];
+
+                                        return callPromiseChain(serialize(__NAME, __VAL), entry => {
+                                                const __NAM = entry.name;
+                                                const __RET = entry.value;
+
+                                                ASSERT_EQUAL(__NAM, __NAME, "Falscher Speicherort");
+                                                return ASSERT_EQUAL(__RET, __EXP, "Symbol falsch gespeichert");
+                                            });
+                                    },
+            'serialize2Symbol2'   : function() {  // NOTE Keine Speicherung von Symbol
+                                        const [ __NAME, __VAL, __EXP ] = __TESTDATA['Symbol2'];
+
+                                        return callPromiseChain(serialize(__NAME, __VAL), entry => {
+                                                const __NAM = entry.name;
+                                                const __RET = entry.value;
+
+                                                ASSERT_EQUAL(__NAM, __NAME, "Falscher Speicherort");
+                                                return ASSERT_EQUAL(__RET, __EXP, "Symbol falsch gespeichert");
+                                            });
+                                    },
             'serialize2Function'  : function() {  // NOTE Keine Speicherung von Function
                                         const [ __NAME, __VAL, __EXP ] = __TESTDATA['Function'];
 
@@ -1133,8 +1297,44 @@
                                                 return ASSERT_EQUAL(__RET, __VAL, "Epsilon falsch geladen");
                                             });
                                     },
+            'deserializeUint32Arr': function() {
+                                        const [ __NAME, __VAL, __EXP ] = __TESTDATA['Uint32Arr'];
+
+                                        return callPromiseChain(storeValue(__NAME, __EXP), entry => deserialize(entry.name, __ERROR), value => {
+                                                const __RET = value;
+
+                                                return ASSERT_EQUAL(__RET, __VAL, "Uint32Array falsch geladen");
+                                            });
+                                    },
+            'deserializeDate'     : function() {
+                                        const [ __NAME, __VAL, __EXP ] = __TESTDATA['Date'];
+
+                                        return callPromiseChain(storeValue(__NAME, __EXP), entry => deserialize(entry.name, __ERROR), value => {
+                                                const __RET = value;
+
+                                                return ASSERT_EQUAL(__RET, __VAL, "Date falsch geladen");
+                                            });
+                                    },
+            'deserializeSymbol'  : function() {  // NOTE Keine Speicherung von Symbol
+                                        const [ __NAME, , __EXP, __ERR ] = __TESTDATA['Symbol'];
+
+                                        return callPromiseChain(storeValue(__NAME, __EXP), entry => deserialize(entry.name, __ERR), value => {
+                                                const __RET = value;
+
+                                                return ASSERT_EQUAL(__RET, __ERR, "Symbol falsch geladen");
+                                            });
+                                    },
+            'deserializeSymbol2'  : function() {  // NOTE Keine Speicherung von Symbol
+                                        const [ __NAME, , __EXP, __ERR ] = __TESTDATA['Symbol2'];
+
+                                        return callPromiseChain(storeValue(__NAME, __EXP), entry => deserialize(entry.name, __ERR), value => {
+                                                const __RET = value;
+
+                                                return ASSERT_EQUAL(__RET, __ERR, "Symbol falsch geladen");
+                                            });
+                                    },
             'deserializeFunction' : function() {  // NOTE Keine Speicherung von Function
-                                        const [ __NAME, __VAL, __EXP, __ERR ] = __TESTDATA['Function'];
+                                        const [ __NAME, , __EXP, __ERR ] = __TESTDATA['Function'];
 
                                         return callPromiseChain(storeValue(__NAME, __EXP), entry => deserialize(entry.name, __ERR), value => {
                                                 const __RET = value;
@@ -1347,6 +1547,42 @@
                                                 const __RET = value;
 
                                                 return ASSERT_EQUAL(__RET, __VAL, "Epsilon falsch geladen");
+                                            });
+                                    },
+            'deserialize2Uint32Arr':function() {
+                                        const [ __NAME, __VAL ] = __TESTDATA['Uint32Arr'];
+
+                                        return callPromiseChain(serialize(__NAME, __VAL), entry => deserialize(entry.name, __ERROR), value => {
+                                                const __RET = value;
+
+                                                return ASSERT_EQUAL(__RET, __VAL, "Uint32Array falsch geladen");
+                                            });
+                                    },
+            'deserialize2Date'    : function() {
+                                        const [ __NAME, __VAL ] = __TESTDATA['Date'];
+
+                                        return callPromiseChain(serialize(__NAME, __VAL), entry => deserialize(entry.name, __ERROR), value => {
+                                                const __RET = value;
+
+                                                return ASSERT_EQUAL(__RET, __VAL, "Date falsch geladen");
+                                            });
+                                    },
+            'deserialize2Symbol'  : function() {  // NOTE Keine Speicherung von Symbol
+                                        const [ __NAME, __VAL, , __ERR ] = __TESTDATA['Symbol'];
+
+                                        return callPromiseChain(serialize(__NAME, __VAL), entry => deserialize(entry.name, __ERR), value => {
+                                                const __RET = value;
+
+                                                return ASSERT_EQUAL(__RET, __ERR, "Symbol falsch geladen");
+                                            });
+                                    },
+            'deserialize2Symbol2' : function() {  // NOTE Keine Speicherung von Symbol
+                                        const [ __NAME, __VAL, , __ERR ] = __TESTDATA['Symbol2'];
+
+                                        return callPromiseChain(serialize(__NAME, __VAL), entry => deserialize(entry.name, __ERR), value => {
+                                                const __RET = value;
+
+                                                return ASSERT_EQUAL(__RET, __ERR, "Symbol falsch geladen");
                                             });
                                     },
             'deserialize2Function': function() {  // NOTE Keine Speicherung von Function


### PR DESCRIPTION
test.assert.js: Fehlermeldung ohne ''
util.object.js: ‹› statt <> wegen Tags (unsichtbar), Länge 0 bzw. null
ignorieren, keine doppelten Typen (Typ raus aus Wert) bei Object und
Function, Symbol('key') verarbeiten
util.store.js: __LOG.info() für value
util.store.test.js: Uint32Arr, Date, Symbol, Symbol2 - 24 neue Tests

