### PR TITLE
Bugfix und Rückbau von 'class' wieder auf 'function'

### DIFF
--- a/misc/OS2/OS2.training.user.js
+++ b/misc/OS2/OS2.training.user.js
@@ -855,8 +855,8 @@ function buildOptions(optConfig, optSet = undefined, optParams = { 'hideMenu' : 
 
 // Klasse ColumnManagerBase *****************************************************************
 
-class ColumnManagerBase {
-    constructor(optSet, colIdx, showCol) {
+/*class*/ function ColumnManagerBase /*{
+    constructor*/(optSet, colIdx, showCol) {
         'use strict';
         UNUSED(optSet, showCol);
 
@@ -923,7 +923,7 @@ class ColumnManagerBase {
         this.kennzE = getOptValue(optSet.kennzeichenEnde);
 ***/
     }
-}
+//}
 
 Class.define(ColumnManagerBase, Object, {
         'toString'       : function() {  // Bisher nur die noetigsten Parameter ausgegeben...
@@ -1003,8 +1003,8 @@ Class.define(ColumnManagerBase, Object, {
 
 // Klasse ColumnManagerZatReport *****************************************************************
 
-class ColumnManagerZatReport extends ColumnManagerBase {
-    constructor(optSet, colIdx, showCol) {
+/*class*/ function ColumnManagerZatReport /*extends ColumnManagerBase {
+    constructor*/(optSet, colIdx, showCol) {
         'use strict';
 
         ColumnManagerBase.call(this, optSet, colIdx, showCol);
@@ -1066,7 +1066,7 @@ class ColumnManagerZatReport extends ColumnManagerBase {
         this.erwB = (__LASTZAT && getValue(__SHOWCOL.zeigeErwartungBalken, __SHOWALL) && getOptValue(optSet.zeigeErwartungBalken));
         this.erf = (__LASTZAT && getValue(__SHOWCOL.zeigeErfolg, __SHOWALL) && getOptValue(optSet.zeigeErfolg));
     }
-}
+//}
 
 Class.define(ColumnManagerZatReport, ColumnManagerBase, {
         'toString'       : function() {  // Bisher nur die noetigsten Parameter ausgegeben...
@@ -1384,8 +1384,8 @@ Class.define(ColumnManagerZatReport, ColumnManagerBase, {
 
 // Klasse PlayerRecordTraining ******************************************************************
 
-class PlayerRecordTraining {
-    constructor(land, age, isGoalie, saison, currZAT, donation) {
+/*class*/ function PlayerRecordTraining /*{
+    constructor*/(land, age, isGoalie, saison, currZAT, donation) {
         'use strict';
 
         this.land = land;
@@ -1430,7 +1430,7 @@ class PlayerRecordTraining {
         // in this.getPos() definiert:
         // this.bestPos: erster (bester) Positionstext
     }
-}
+//}
 
 Class.define(PlayerRecordTraining, Object, {
         '__TIME'                : {   // Zeitpunktangaben

--- a/misc/OS2/lib/OS2.class.column.js
+++ b/misc/OS2/lib/OS2.class.column.js
@@ -16,8 +16,8 @@
 
 // Klasse fuer Spalten des Jugendkaders
 
-class ColumnManager {
-    constructor(optSet, colIdx, showCol) {
+/*class*/ function ColumnManager /*{
+    constructor*/(optSet, colIdx, showCol) {
         'use strict';
 
         __LOG[4]("ColumnManager()");
@@ -79,7 +79,7 @@ class ColumnManager {
         this.anzMwE = ((__PROJECTION && getValue(__SHOWCOL.zeigeMWEnde, __SHOWALL)) ? getOptValue(optSet.anzahlMWEnde) : 0);
         this.kennzE = getOptValue(optSet.kennzeichenEnde);
     }
-}
+//}
 
 Class.define(ColumnManager, Object, {
         'toString'       : function() {  // Bisher nur die noetigsten Parameter ausgegeben...

--- a/misc/OS2/lib/OS2.class.player.js
+++ b/misc/OS2/lib/OS2.class.player.js
@@ -16,8 +16,8 @@
 
 // Klasse fuer Spalten des Jugendkaders
 
-class PlayerRecord {
-    constructor(land, age, isGoalie, saison, currZAT, donation) {
+/*class*/ function PlayerRecord /*{
+    constructor*/(land, age, isGoalie, saison, currZAT, donation) {
         'use strict';
 
         this.land = land;
@@ -62,7 +62,7 @@ class PlayerRecord {
         // in this.getPos() definiert:
         // this.bestPos: erster (bester) Positionstext
     }
-}
+//}
 
 Class.define(PlayerRecord, Object, {
         '__TIME'                : {   // Zeitpunktangaben

--- a/misc/OS2/lib/OS2.class.table.js
+++ b/misc/OS2/lib/OS2.class.table.js
@@ -16,8 +16,8 @@
 
 // Klasse fuer Tabelle
 
-class TableManager {
-    constructor(optSet, colIdx, rows, offsetUpper, offsetLower) {
+/*class*/ function TableManager /*{
+    constructor*/(optSet, colIdx, rows, offsetUpper, offsetLower) {
         'use strict';
 
         Object.call(this);
@@ -45,7 +45,7 @@ class TableManager {
         this.isAbschluss = (this.getSpieltag() === this.letzterSpieltag);
         this.isCurrSaison = (this.saison === this.currSaison);
     }
-}
+//}
 
 Class.define(TableManager, Object, {
         'createVereine'  : function() {

--- a/misc/OS2/lib/OS2.class.warndraw.js
+++ b/misc/OS2/lib/OS2.class.warndraw.js
@@ -16,8 +16,8 @@
 
 // Klasse fuer Ziehwarnung fuer einen Jugendspieler
 
-class WarnDrawPlayer {
-    constructor(player, alertColor) {
+/*class*/ function WarnDrawPlayer /*{
+    constructor*/(player, alertColor) {
         'use strict';
 
         this.player = player;
@@ -36,21 +36,19 @@ class WarnDrawPlayer {
             this.colAlert = undefined;
         }
     }
-
-    setZatLeft(zatLeft) {
-        this.zatLeft = zatLeft;
-    }
-
-    setWarn(warn, warnMonth, warnAufstieg) {
-        this.warn = (this.aufstieg ? warnAufstieg : warn);
-        this.warnMonth = warnMonth;
-    }
-}
+//}
 
 Class.define(WarnDrawPlayer, Object, {
         '__MONATEBISABR'    : 1,
         '__ZATWARNVORLAUF'  : 1,
         '__ZATMONATVORLAUF' : 6,
+        'setZatLeft'        : function(zatLeft) {
+                                  this.zatLeft = zatLeft;
+                              },
+        'setWarn'           : function(warn, warnMonth, warnAufstieg) {
+                                  this.warn = (this.aufstieg ? warnAufstieg : warn);
+                                  this.warnMonth = warnMonth;
+                              },
         'alertColor'        : function() {
                                   return getColor('STU');  // rot
                               },
@@ -91,8 +89,8 @@ const __NOWARNDRAW = new WarnDrawPlayer(undefined, undefined);  // inaktives Obj
 
 // Klasse fuer Warnmeldung fuer einen Jugendspieler
 
-class WarnDrawMessage {
-    constructor(optSet, currZAT) {
+/*class*/ function WarnDrawMessage /*{
+    constructor*/(optSet, currZAT) {
         'use strict';
 
         this.optSet = optSet;
@@ -116,7 +114,7 @@ class WarnDrawMessage {
 
         this.startMessage(currZAT);
     }
-}
+//}
 
 Class.define(WarnDrawMessage, Object, {
         '__ZATWARNVORLAUF'  : 1,
@@ -277,8 +275,8 @@ Object.defineProperty(WarnDrawMessage.prototype, 'innerHTML', {
 
 // Klasse fuer Warnmeldung im Falle eines Aufstiegs fuer einen Jugendspieler
 
-class WarnDrawMessageAufstieg extends WarnDrawMessage {
-    constructor(optSet, currZAT) {
+/*class*/ function WarnDrawMessageAufstieg /*extends WarnDrawMessage {
+    constructor*/(optSet, currZAT) {
         'use strict';
 
         WarnDrawMessage.call(this, optSet, currZAT);
@@ -288,7 +286,7 @@ class WarnDrawMessageAufstieg extends WarnDrawMessage {
         this.warn = (this.warn && this.warnAufstieg);  // kann man ausschalten
         this.startMessage(currZAT);  // 2. Aufruf (zur Korrektur)
     }
-}
+//}
 
 Class.define(WarnDrawMessageAufstieg, WarnDrawMessage, {
         'configureZat'      : function() {

--- a/misc/OS2/lib/OS2.team.js
+++ b/misc/OS2/lib/OS2.team.js
@@ -23,8 +23,8 @@
 
 // Klasse fuer die Klassifikation der Optionen nach Team (Erst- und Zweitteam oder Fremdteam)
 
-class TeamClassification extends Classification {
-    constructor() {
+/*class*/ function TeamClassification /*extends Classification {
+    constructor*/() {
         'use strict';
 
         Classification.call(this);
@@ -34,7 +34,7 @@ class TeamClassification extends Classification {
         this.team = undefined;
         this.teamParams = undefined;
     }
-}
+//}
 
 Class.define(TeamClassification, Classification, {
                     'renameParamFun' : function() {
@@ -57,8 +57,8 @@ Class.define(TeamClassification, Classification, {
 
 // Klasse fuer Teamdaten
 
-class Team {
-    constructor(team, land, liga) {
+/*class*/ function Team /*{
+    constructor*/(team, land, liga) {
         'use strict';
 
         this.Team = team;
@@ -67,7 +67,7 @@ class Team {
         this.LdNr = getLandNr(land);
         this.LgNr = getLigaNr(liga);
     }
-}
+//}
 
 Class.define(Team, Object, {
                     '__TEAMITEMS' : {   // Items, die in Team als Teamdaten gesetzt werden...
@@ -85,8 +85,8 @@ Class.define(Team, Object, {
 
 // Klasse fuer Vereinsdaten
 
-class Verein extends Team {
-    constructor(team, land, liga, id, manager, flags) {
+/*class*/ function Verein /*extends Team {
+    constructor*/(team, land, liga, id, manager, flags) {
         'use strict';
 
         Team.call(this, team, land, liga);
@@ -95,7 +95,7 @@ class Verein extends Team {
         this.Manager = manager;
         this.Flags = (flags || []);
     }
-}
+//}
 
 Class.define(Verein, Team, {
                     '__TEAMITEMS' : {   // Items, die in Verein als Teamdaten gesetzt werden...

--- a/misc/OS2/lib/OS2.zat.js
+++ b/misc/OS2/lib/OS2.zat.js
@@ -23,8 +23,8 @@ const __HINRUECK    = [ " Hin", " R\xFCck", "" ];
 
 // ==================== Abschnitt fuer Klasse RundenLink ====================
 
-class RundenLink {
-    constructor(saison, team) {
+/*class*/ function RundenLink /*{
+    constructor*/(saison, team) {
         'use strict';
 
         this.uri = new URI("http://os.ongapo.com/");
@@ -41,7 +41,7 @@ class RundenLink {
             this.setTeam(team);
         }
     }
-}
+//}
 
 Class.define(RundenLink, Object, {
         'setSaison'    : function(saison) {

--- a/misc/OS2/lib/test.assert.js
+++ b/misc/OS2/lib/test.assert.js
@@ -52,8 +52,9 @@ async function callPromiseArray(...promises) {
 // msg: Text oder Text liefernde Funktion
 // thisArg: Referenz auf ein Bezugsobjekt
 // params: ggfs. Parameter fuer die msg-Funktion
-class AssertionFailed {
-    constructor(whatFailed, msg, thisArg, ...params) {
+
+/*class*/ function AssertionFailed /*{
+    constructor*/(whatFailed, msg, thisArg, ...params) {
         //'use strict';
         const __THIS = (thisArg || this);
 
@@ -71,7 +72,7 @@ class AssertionFailed {
             this.message += " (" + whatFailed + ')';
         }
     }
-}
+//}
 
 Class.define(AssertionFailed, Object, {
                   'getTextMessage'    : function() {

--- a/misc/OS2/lib/test.class.unittest.js
+++ b/misc/OS2/lib/test.class.unittest.js
@@ -387,8 +387,9 @@ UnitTest.getStyleFromResults = function(results) {
 // libName: Name des JS-Moduls
 // libDesc: Beschreibung des Moduls
 // libTest: UnitTest-Klasse des Moduls
-class UnitTestResults {
-    constructor(libName, libDesc, libTest) {
+
+/*class*/ function UnitTestResults /*{
+    constructor*/(libName, libDesc, libTest) {
         'use strict';
 
         this.name = libName;
@@ -401,7 +402,7 @@ class UnitTestResults {
         this.countException = 0;  // Zaehler EX (andere Exceptions ausser ERR)
         this.countError     = 0;  // Zaehler ERR (Fehler im Test, Spezial-Exception)
     }
-}
+//}
 
 Class.define(UnitTestResults, Object, {
                 'running'             : function() {

--- a/misc/OS2/lib/util.class.js
+++ b/misc/OS2/lib/util.class.js
@@ -21,8 +21,8 @@ if ((typeof showAlert) === 'undefined') {
 
 // ==================== Abschnitt fuer Klasse Class ====================
 
-class Class {
-    constructor(className, baseClass, initFun) {
+/*class*/ function Class /*{
+    constructor*/(className, baseClass, initFun) {
         'use strict';
 
         try {
@@ -58,7 +58,7 @@ class Class {
             return showException('[' + (ex && ex.lineNumber) + "] Error in Class " + className, ex);
         }
     }
-}
+//}
 
 Class.define = function(subClass, baseClass, members = undefined, initFun = undefined, createProto = true) {
         return (subClass.prototype = subClass.subclass(baseClass, members, initFun, createProto));

--- a/misc/OS2/lib/util.class.path.js
+++ b/misc/OS2/lib/util.class.path.js
@@ -24,8 +24,9 @@
 // 'back': Name des relativen Vaterverzeichnisses
 // 'root': Kennung vor dem ersten Trenner am Anfang eines absoluten Pfads
 // 'home': Kennung vor dem ersten Trenner am Anfang eines Pfads relativ zu Home
-class Path {
-    constructor(homePath, delims) {
+
+/*class*/ function Path /*{
+    constructor*/(homePath, delims) {
         'use strict';
 
         this.dirs = [];
@@ -34,7 +35,7 @@ class Path {
 
         this.home();
     }
-}
+//}
 
 Class.define(Path, Object, {
                   'root'           : function() {

--- a/misc/OS2/lib/util.class.uri.js
+++ b/misc/OS2/lib/util.class.uri.js
@@ -24,8 +24,9 @@
 // 'back': Name des relativen Vaterverzeichnisses
 // 'root': Kennung vor dem ersten Trenner am Anfang eines absoluten Pfads
 // 'home': Kennung vor dem ersten Trenner am Anfang eines Pfads relativ zu Home
-class URI extends Path {
-    constructor(homePath, delims) {
+
+/*class*/ function URI /*extends Path {
+    constructor*/(homePath, delims) {
         'use strict';
 
         UNUSED(delims);
@@ -44,7 +45,7 @@ class URI extends Path {
 
         this.home();
     }
-}
+//}
 
 Class.define(URI, Path, {
                'setDelims'         : function() {

--- a/misc/OS2/lib/util.main.js
+++ b/misc/OS2/lib/util.main.js
@@ -17,11 +17,11 @@
 // Gesetzte Optionen (werden ggfs. von initOptions() angelegt und von loadOptions() gefuellt):
 //const __OPTSET = new Options(__OPTCONFIG, '__OPTSET');
 
-class Main {
-    constructor(optConfig, optSet, classification) {
+/*class*/ function Main /*{
+    constructor*/(optConfig, optSet, classification) {
         UNUSED(optConfig, optSet, classification);
     }
-}
+//}
 
 //const __MAIN = new Main(__OPTCONFIG, __OPTSET, __TEAMCLASS);
 

--- a/misc/OS2/lib/util.option.run.js
+++ b/misc/OS2/lib/util.option.run.js
@@ -146,8 +146,9 @@ function initOptions(optConfig, optSet = undefined, preInit = undefined) {
 // ==================== Abschnitt fuer Klasse Classification ====================
 
 // Basisklasse fuer eine Klassifikation der Optionen nach Kriterium (z.B. Erst- und Zweitteam oder Fremdteam)
-class Classification {
-    constructor(prefix) {
+
+/*class*/ function Classification /*{
+    constructor*/(prefix) {
         'use strict';
 
         this.renameFun = prefixName;
@@ -155,7 +156,7 @@ class Classification {
         this.optSet = undefined;
         this.optSelect = { };
     }
-}
+//}
 
 Class.define(Classification, Object, {
                     'renameOptions'  : function() {
@@ -216,8 +217,9 @@ function optSelect(selList, ignList) {
 // ==================== Abschnitt fuer Klasse ClassificationPair ====================
 
 // Klasse fuer die Klassifikation der Optionen nach Team (Erst- und Zweitteam oder Fremdteam)
-class ClassificationPair extends Classification {
-    constructor(classA, classB) {
+
+/*class*/ function ClassificationPair /*extends Classification {
+    constructor*/(classA, classB) {
         'use strict';
 
         Classification.call(this);
@@ -265,7 +267,7 @@ class ClassificationPair extends Classification {
                               }
                     });
     }
-}
+//}
 
 Class.define(ClassificationPair, Classification, {
                     'renameOptions'  : function() {


### PR DESCRIPTION
class (ES6) wird noch von zu wenigen Browsern unterstützt:
Daher 'class', 'extends' und 'constructor' auskommentiert.
Stattdessen 'function' wieder eingebaut. Dies betrifft nach
letzter Zählung 22 Klassen. Unit-Tests funktionieren wieder.

