### PR TITLE
Unit-Tests für Optionen, Debugginghilfe, Überprüfungen

### DIFF
--- a/misc/OS2/lib/lib.all.js
+++ b/misc/OS2/lib/lib.all.js
@@ -838,7 +838,7 @@ Object.defineProperty(Array.prototype, 'Reduce', {
     'enumerable'      : false,
     'value'           : function(reduceFun, value) {
         if ((! reduceFun) || ((typeof reduceFun) !== 'function')) {
-            throw TypeError();
+            throw TypeError("Invalid reduce() function!");
         }
 
         const __LEN = this.length;
@@ -869,7 +869,7 @@ Object.defineProperty(Array.prototype, 'ReduceRight', {
     'enumerable'      : false,
     'value'           : function(reduceFun, value) {
         if ((! reduceFun) || ((typeof reduceFun) !== 'function')) {
-            throw TypeError();
+            throw TypeError("Invalid reduceRight() function!");
         }
 
         const __LEN = this.length;
@@ -1164,7 +1164,7 @@ function ScriptModule(meta) {
             set           : undefined
         });
 
-    __LOG[2](__DBMOD);
+    __LOG[1](__DBMOD);
 
     return __DBMOD;
 }
@@ -1275,6 +1275,51 @@ function defaultCatch(error, show) {
         return Promise.reject(showException(__LABEL, error, show));
     } catch (ex) {
         return Promise.reject(showException(`[${ex && ex.lineNumber}] ${__DBMOD.Name}`, ex, true));
+    }
+}
+
+// Ermittlung der gerade signifikanten Quellcode-Stelle des Programmablaufs
+// longForm: Ausgabe des vollen Pfades anstelle von nur dem Dateinamen und der Zeilennummer
+// showFunName: Neben Datei und Zeilennummer zusaetzlich Funktionsnamen zurueckgeben (Default: false)
+// ignoreCaller: Neben codeLine() auch den Caller ignorieren, als Zahl: Anzahl der Caller (Default: false)
+// ignoreLibs (empfohlen): Ueberspringen von lib*.js-Eintraegen (ausser beim untersten Aufruf)
+// return Liefert Dateiname:Zeilennummer des Aufrufers als String
+function codeLine(longForm = false, showFunName = false, ignoreCaller = false, ignoreLibs = true) {
+    try {
+        const __STACK = Error().stack.split("\n");
+        let countCaller = Number(ignoreCaller);  // Normalerweise 0 oder 1, bei 2 wird auch der naechste Aufrufer ignoriert!
+        let ret;
+        let nameLine;
+        let funName;
+
+        for (let i = 1 /* ohne codeLine() selber */; i < __STACK.length; i++) {
+            const __LINE = __STACK[i];
+            if (! __LINE) { break; }
+            const [ __FUNNAME, __LOCATION ] = __LINE.split('@', 2);
+            const __NAMELINE = getValue(__LOCATION, "").replace(/.*\//, ""); 
+
+            if (countCaller-- > 0) {
+                // Aufrufer wird ignoriert...
+                continue;
+            }
+
+            if (ignoreLibs && __NAMELINE.match(/^lib\./)) {  // "lib.*"
+                if (! ret) {
+                    [ ret, nameLine, funName ] = [ __LOCATION, __NAMELINE, __FUNNAME ];
+                }
+                continue;
+            }
+            [ ret, nameLine, funName ] = [ __LOCATION, __NAMELINE, __FUNNAME ];
+            break;
+        }
+
+        if (ret && ! longForm) {
+            ret = nameLine;
+        }
+
+        return ret + (showFunName ? (':' + funName) : "");
+    } catch (ex) {
+        return showException("Error in codeLine()", ex);
     }
 }
 
@@ -3126,7 +3171,7 @@ function setOptValue(opt, value) {
 function getOptValue(opt, defValue = undefined) {
     let value;
 
-    if (opt && opt.Loaded) {
+    if (opt /*&& opt.Loaded*/) {  // NOTE opt.Loaded steuert das Laden, aber opt.Value den Wert
         value = getValue(opt.Value, defValue);
     }
 
@@ -3385,7 +3430,7 @@ Class.define(Options, Object, {
 
 /*** Modul util.option.api.js ***/
 
-// ==UserScript==
+// // ==UserScript==
 // _name         util.option.api
 // _namespace    http://os.ongapo.com/
 // _version      0.10
@@ -3408,15 +3453,37 @@ Class.define(Options, Object, {
 
 // ==================== Abschnitt Operationen auf Optionen ====================
 
+// Prueft ein Objekt, ob es eine syntaktisch valide (ueber Menu) gesetzte Option ist
+// opt: Zu validierendes Options-Objekt
+// return [__CONFIG, __NAME, ...] Konfiguration und ggfs. Name der Option
+function checkOpt(opt) {
+    if (opt === undefined) {
+        throw Error("Option is undefined");
+    }
+
+    const __CONFIG = getOptConfig(opt);
+    const __NAME = getOptName(opt);
+
+    if (! opt.validOption) {
+        if (((typeof __NAME) !== 'undefined') && __NAME.length && ((typeof __CONFIG) === 'object')) {
+            opt.validOption = true;
+        } else {
+            throw TypeError("Invalid option (" + __LOG.info(__NAME, false) + "): " + __LOG.info(opt, true));
+        }
+    }
+
+    return [ __CONFIG, __NAME ];
+}
+
 // Invalidiert eine (ueber Menu) gesetzte Option
 // opt: Zu invalidierende Option
 // force: Invalidiert auch Optionen mit 'AutoReset'-Attribut
 // return Promise auf resultierenden Wert
 function invalidateOpt(opt, force = false, reload = true) {
+    const [ __CONFIG ] = checkOpt(opt);
+
     return Promise.resolve(opt.Promise).then(() => {
             if (opt.Loaded && reload && ! opt.ReadOnly) {
-                const __CONFIG = getOptConfig(opt);
-
                 // Wert "ungeladen"...
                 opt.Loaded = (force || ! __CONFIG.AutoReset);
 
@@ -3424,6 +3491,8 @@ function invalidateOpt(opt, force = false, reload = true) {
                     // Nur zuruecksetzen, gilt als geladen...
                     setOptValue(opt, initOptValue(__CONFIG));
                 }
+            } else {  // ! opt.Loaded || ! reload || opt.ReadOnly
+                opt.Loaded = false;
             }
 
             return getOptValue(opt);
@@ -3449,10 +3518,10 @@ async function invalidateOpts(optSet, force = false, reload = true) {
 // force: Laedt auch Optionen mit 'AutoReset'-Attribut
 // return Promise auf gesetzten Wert der gelandenen Option
 function loadOption(opt, force = false) {
+    const [ __CONFIG, __NAME ] = checkOpt(opt);
+
     if (! opt.Promise) {
-        const __CONFIG = getOptConfig(opt);
         const __ISSHARED = getValue(__CONFIG.Shared, false, true);
-        const __NAME = getOptName(opt);
         const __DEFAULT = getOptValue(opt, undefined);
         let value;
 
@@ -3477,7 +3546,7 @@ function loadOption(opt, force = false) {
         opt.Promise = Promise.resolve(value).then(value => {
                 // Paranoide Sicherheitsabfrage (das sollte nie passieren!)...
                 if (opt.Loaded || ! opt.Promise) {
-                    showAlert("Error", "Unerwarteter Widerspruch zwischen opt.Loaded und opt.Promise", safeStringify(opt));
+                    showAlert("Error", "Unerwarteter Widerspruch zwischen opt.Loaded und opt.Promise", __LOG.info(opt, true, true));
                 }
                 __LOG[6]("LOAD " + __NAME + ": " + __LOG.changed(__DEFAULT, value, true, true));
 
@@ -3528,10 +3597,9 @@ function loadOptions(optSet, force = false) {
 // reset: Setzt bei Erfolg auf Initialwert der Option (auch fuer nicht 'AutoReset')
 // return Promise von GM.deleteValue() (oder void)
 function deleteOption(opt, force = false, reset = true) {
-    const __CONFIG = getOptConfig(opt);
+    const [ __CONFIG, __NAME ] = checkOpt(opt);
 
     if (force || ! __CONFIG.Permanent) {
-        const __NAME = getOptName(opt);
         const __VALUE = getOptValue(opt, undefined, false);
         let newValue;
 
@@ -3569,10 +3637,9 @@ async function deleteOptions(optSet, optSelect = undefined, force = false, reset
 // opt: Gesetzte Option
 // return Promise von setOptValue() (oder void)
 function saveOption(opt) {
-    const __CONFIG = getOptConfig(opt);
+    const [ __CONFIG, __NAME ] = checkOpt(opt);
 
     if (__CONFIG !== undefined) {
-        const __NAME = getOptName(opt);
         const __VALUE = getOptValue(opt);
 
         __LOG[4]("SAVE " + __NAME);
@@ -3607,7 +3674,7 @@ async function saveOptions(optSet, optSelect = undefined) {
 // force: Laedt auch Optionen mit 'AutoReset'-Attribut
 // return Promise auf umbenannte Option
 async function renameOption(opt, name, reload = false, force = false) {
-    const __NAME = getOptName(opt);
+    const [ , __NAME ] = checkOpt(opt);
 
     if (__NAME !== name) {
         await deleteOption(opt, true, false);
@@ -3697,21 +3764,23 @@ async function resetOptions(optSet, reload = true) {
 // force: Laedt auch Optionen mit 'AutoReset'-Attribut
 // return Gesetzter Wert bzw. ein Promise darauf bei asyncLoad
 function loadOptValue(opt, defValue = undefined, asyncLoad = true, force = false) {
+    if (! opt) {
+        return Promise.reject("loadOptValue: Option ist undefined");
+    }
+
+    const [ , __NAME ] = checkOpt(opt);
+
     if (asyncLoad) {
-        if (! opt) {
-            return Promise.reject("loadOptValue: Option ist undefined");
-        } else {
-            let promise = (opt.Loaded ? Promise.resolve(opt.Value) : opt.Promise);
+        let promise = (opt.Loaded ? Promise.resolve(opt.Value) : opt.Promise);
 
-            if (! promise) {
-                promise = loadOption(opt, force);
-            }
-
-            return promise.then(value => valueOf(getValue(value, defValue)));
+        if (! promise) {
+            promise = loadOption(opt, force);
         }
+
+        return promise.then(value => valueOf(getValue(value, defValue)));
     } else {
-        if (! (opt && opt.Loaded)) {
-            __LOG[1](`Warnung: loadOptValue(${getOptName(opt)}) erlaubt kein Nachladen!`);
+        if (! opt.Loaded) {
+            __LOG[1]("Warnung: loadOptValue(" + __LOG.info(__NAME, false) + ") erlaubt kein Nachladen!");
         }
 
         return getOptValue(opt, defValue);

--- a/misc/OS2/lib/test.assert.js
+++ b/misc/OS2/lib/test.assert.js
@@ -18,17 +18,28 @@
 // ==================== Abschnitt fuer einfaches Testen von Arrays von Promises und Funktionen ====================
 
 // Funktion zum sequentiellen Aufruf eines Arrays von Funktionen ueber Promises
-// startValue: Promise oder Wert, der/die den Startwert oder das Startobjekt beinhaltet
+// startValue: Promise, das den Startwert oder das Startobjekt beinhaltet
 // funs: Liste oder Array von Funktionen, die jeweils das Zwischenergebnis umwandeln
 // throw Wirft im Fehlerfall eine AssertionFailed-Exception
 // return Ein Promise-Objekt mit dem Endresultat
 async function callPromiseChain(startValue, ...funs) {
+    if (startValue !== undefined) {
+        if (((typeof startValue) !== 'object') || ! (startValue instanceof Promise)) {
+            throw TypeError("callPromiseChain(): startValue should be a Promise!");
+        }
+    }
+    funs.forEach((fun, index) => {
+            if ((typeof fun) !== 'function') {
+                throw TypeError("callPromiseChain(): Parameter #" + (index + 1) + " should be a Function!");
+            }
+        });
+
     return funs.flat(1).reduce((prom, fun, idx, arr) => prom.then(fun, ex => assertionCatch(ex, {
             'function'  : fun,
             'param'     : prom,
             'array'     : arr,
             'index'     : idx
-        })), Promise.resolve(startValue));
+        })), startValue);
 }
 
 // Funktion zum parallelen Aufruf eines Arrays von Promises bzw. Promise-basierten Funktionen

--- a/misc/OS2/lib/test.class.unittest.js
+++ b/misc/OS2/lib/test.class.unittest.js
@@ -15,7 +15,11 @@
 /* jshint esnext: true */
 /* jshint moz: true */
 
-__LOG.init(window, 9);  // Testphase
+// ==================== Konfigurations-Abschnitt fuer Optionen ====================
+
+const __TESTLOGLEVEL = 9;
+
+__LOG.init(window, __TESTLOGLEVEL);  // Testphase
 
 // ==================== Abschnitt fuer Klasse UnitTest ====================
 

--- a/misc/OS2/lib/test.lib.option.js
+++ b/misc/OS2/lib/test.lib.option.js
@@ -32,21 +32,47 @@ function UnitTestOption(name, desc, tests, load) {
 
 Class.define(UnitTestOption, UnitTest, {
             'prepare'     : async function(name, desc, thisArg, resultObj, resultFun, tableId) {
-                                UNUSED(thisArg, resultObj, resultFun, tableId);
+                                UNUSED(resultObj, resultFun, tableId);
+
+                                const __TEAMPARAMS = new Team("Choromonets Odessa", "Ukraine", "1. Liga");
 
                                 __LOG[1]("prepare()", name, desc);
+
+                                thisArg.optSet = await buildOptions(__TESTOPTCONFIG, __TESTOPTSET, {
+                                        'teamParams'  : __TEAMPARAMS,
+                                        'menuAnchor'  : getTable(1, 'div'),
+                                        'hideMenu'    : true,
+                                        'hideForm'    : {
+                                                           'team'   : true
+                                                        }
+                                    });
 
                                 return true;
                             },
             'cleanup'     : async function(name, desc, thisArg, resultObj, resultFun, tableId) {
-                                UNUSED(thisArg, resultObj, resultFun, tableId);
+                                UNUSED(resultFun, tableId);
+
+                                const __RELOAD = false;
 
                                 __LOG[1]("cleanup()", name, desc);
+
+                                // Status loggen...
+                                __LOG[2](String(thisArg.optSet));
+                                __LOG[1]('OPTION TEST END', __DBMOD.Name, '(' + resultObj.countRunning + ')');
+
+                                // Optionen aufraeumen...
+                                await resetOptions(this.optSet, __RELOAD);
+                                delete thisArg.optSet;
 
                                 return true;
                             },
             'setup'       : async function(name, desc, testFun, thisArg) {
+                                const __RELOAD = false;
+
                                 __LOG[1]("setup()", name, desc, testFun, thisArg);
+
+                                // "Sauberes" OptSet vorbereiten...
+                                await resetOptions(this.optSet, __RELOAD);
 
                                 return true;
                             },
@@ -58,5 +84,150 @@ Class.define(UnitTestOption, UnitTest, {
         });
 
 // ==================== Ende Abschnitt fuer Klasse UnitTestOption ====================
+
+// ==================== Ende Abschnitt fuer Test-Konfiguration __TESTCONFIG ====================
+
+// Moegliche Optionen (hier die Standardwerte editieren oder ueber das Benutzermenu setzen):
+const __TESTOPTCONFIG = {
+    'saison' : {          // Laufende Saison
+                   'Name'      : "saison",
+                   'Type'      : __OPTTYPES.MC,
+                   'ValType'   : 'Number',
+                   'FreeValue' : true,
+                   'SelValue'  : false,
+                   'Choice'    : [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25 ],
+                   'Default'   : 17,
+                   'Action'    : __OPTACTION.NXT,
+                   'Label'     : "Saison: $",
+                   'Hotkey'    : 'a',
+                   'FormLabel' : "Saison:|$"
+               },
+    'ligaSize' : {        // Ligengroesse
+                   'Name'      : "ligaSize",
+                   'Type'      : __OPTTYPES.MC,
+                   'ValType'   : 'Number',
+                   'AutoReset' : true,
+                   'Choice'    : [ 10, 18, 20 ],
+                   'Action'    : __OPTACTION.NXT,
+                   'Label'     : "Liga: $er",
+                   'Hotkey'    : 'i',
+                   'FormLabel' : "Liga:|$er"
+               },
+    'datenZat' : {        // Stand der Daten zum Team und ZAT
+                   'Name'      : "dataZAT",
+                   'Type'      : __OPTTYPES.SD,
+                   'ValType'   : 'Number',
+                   'Hidden'    : true,
+                   'Serial'    : true,
+                   'AutoReset' : true,
+                   'Permanent' : true,
+                   'Default'   : undefined,
+                   'Action'    : __OPTACTION.SET,
+                   'Submit'    : undefined,
+                   'Cols'      : 3,
+                   'Rows'      : 1,
+                   'Replace'   : null,
+                   'Space'     : 0,
+                   'Label'     : "Daten-ZAT: $"
+               },
+    'team' : {            // Datenspeicher fuer Daten des Erst- bzw. Zweitteams
+                   'Name'      : "team",
+                   'Type'      : __OPTTYPES.SD,
+                   'Hidden'    : true,
+                   'Serial'    : true,
+                   'Permanent' : true,
+                   'Default'   : undefined,  // new Team() // { 'Team' : undefined, 'Liga' : undefined, 'Land' : undefined, 'LdNr' : 0, 'LgNr' : 0 }
+                   'Submit'    : undefined,
+                   'Cols'      : 36,
+                   'Rows'      : 6,
+                   'Replace'   : null,
+                   'Space'     : 1,
+                   'Label'     : "Verein:"
+               },
+    'reset' : {           // Optionen auf die "Werkseinstellungen" zuruecksetzen
+                   'FormPrio'  : undefined,
+                   'Name'      : "reset",
+                   'Type'      : __OPTTYPES.SI,
+                   'Action'    : __OPTACTION.RST,
+                   'Label'     : "Standard-Optionen",
+                   'Hotkey'    : 'O',
+                   'FormLabel' : ""
+               },
+    'storage' : {         // Browserspeicher fuer die Klicks auf Optionen
+                   'FormPrio'  : undefined,
+                   'Name'      : "storage",
+                   'Type'      : __OPTTYPES.MC,
+                   'ValType'   : 'String',
+                   'Choice'    : Object.keys(__OPTMEM),
+                   'Action'    : __OPTACTION.NXT,
+                   'Label'     : "Speicher: $",
+                   'Hotkey'    : 'c',
+                   'FormLabel' : "Speicher:|$"
+               },
+    'oldStorage' : {      // Vorheriger Browserspeicher fuer die Klicks auf Optionen
+                   'FormPrio'  : undefined,
+                   'Name'      : "oldStorage",
+                   'Type'      : __OPTTYPES.SD,
+                   'PreInit'   : true,
+                   'AutoReset' : true,
+                   'Hidden'    : true
+               },
+    'showForm' : {        // Optionen auf der Webseite (true = anzeigen, false = nicht anzeigen)
+                   'FormPrio'  : 1,
+                   'Name'      : "showForm",
+                   'Type'      : __OPTTYPES.SW,
+                   'FormType'  : __OPTTYPES.SI,
+                   'Permanent' : true,
+                   'Default'   : false,
+                   'Title'     : "$V Optionen",
+                   'Action'    : __OPTACTION.NXT,
+                   'Label'     : "Optionen anzeigen",
+                   'Hotkey'    : 'a',
+                   'AltTitle'  : "$V schlie\xDFen",
+                   'AltLabel'  : "Optionen verbergen",
+                   'AltHotkey' : 'v',
+                   'FormLabel' : ""
+               }
+};
+
+// ==================== Ende Abschnitt fuer Test-Konfiguration __TESTCONFIG ====================
+
+// ==================== Spezialisierter Abschnitt fuer Optionen ====================
+
+// Gesetzte Optionen (werden ggfs. von initOptions() angelegt und von loadOptions() gefuellt):
+const __TESTOPTSET = new Options(__TESTOPTCONFIG, '__TESTOPTSET');
+
+// Teamparameter fuer getrennte Speicherung der Optionen fuer Erst- und Zweitteam...
+const __TESTTEAMCLASS = new TeamClassification();
+
+// Optionen mit Daten, die ZAT- und Team-bezogen gemerkt werden...
+__TESTTEAMCLASS.optSelect = {
+//        'datenZat'   : true,
+//        'ligaSize'   : true
+    };
+
+// Behandelt die Optionen und laedt das Benutzermenu
+// optConfig: Konfiguration der Optionen
+// optSet: Platz fuer die gesetzten Optionen
+// optParams: Eventuell notwendige Parameter zur Initialisierung
+// 'hideMenu': Optionen werden zwar geladen und genutzt, tauchen aber nicht im Benutzermenu auf
+// 'teamParams': Getrennte Daten-Option wird genutzt, hier: Team() mit 'LdNr'/'LgNr' des Erst- bzw. Zweitteams
+// 'menuAnchor': Startpunkt fuer das Optionsmenu auf der Seite
+// 'showForm': Checkliste der auf der Seite sichtbaren Optionen (true fuer sichtbar)
+// 'hideForm': Checkliste der auf der Seite unsichtbaren Optionen (true fuer unsichtbar)
+// 'formWidth': Anzahl der Elemente pro Zeile
+// 'formBreak': Elementnummer des ersten Zeilenumbruchs
+// return Promise auf gefuelltes Objekt mit den gesetzten Optionen
+function buildOptions(optConfig, optSet = undefined, optParams = { 'hideMenu' : false }) {
+    // Klassifikation ueber Land und Liga des Teams...
+    __TESTTEAMCLASS.optSet = optSet;  // Classification mit optSet verknuepfen
+    __TESTTEAMCLASS.teamParams = optParams.teamParams;  // Ermittelte Parameter
+
+    return startOptions(optConfig, optSet, __TESTTEAMCLASS).then(
+                optSet => showOptions(optSet, optParams),
+                defaultCatch);
+}
+
+// ==================== Ende Abschnitt fuer Optionen ====================
 
 // *** EOF ***

--- a/misc/OS2/lib/util.debug.js
+++ b/misc/OS2/lib/util.debug.js
@@ -66,6 +66,51 @@ function defaultCatch(error, show) {
     }
 }
 
+// Ermittlung der gerade signifikanten Quellcode-Stelle des Programmablaufs
+// longForm: Ausgabe des vollen Pfades anstelle von nur dem Dateinamen und der Zeilennummer
+// showFunName: Neben Datei und Zeilennummer zusaetzlich Funktionsnamen zurueckgeben (Default: false)
+// ignoreCaller: Neben codeLine() auch den Caller ignorieren, als Zahl: Anzahl der Caller (Default: false)
+// ignoreLibs (empfohlen): Ueberspringen von lib*.js-Eintraegen (ausser beim untersten Aufruf)
+// return Liefert Dateiname:Zeilennummer des Aufrufers als String
+function codeLine(longForm = false, showFunName = false, ignoreCaller = false, ignoreLibs = true) {
+    try {
+        const __STACK = Error().stack.split("\n");
+        let countCaller = Number(ignoreCaller);  // Normalerweise 0 oder 1, bei 2 wird auch der naechste Aufrufer ignoriert!
+        let ret;
+        let nameLine;
+        let funName;
+
+        for (let i = 1 /* ohne codeLine() selber */; i < __STACK.length; i++) {
+            const __LINE = __STACK[i];
+            if (! __LINE) { break; }
+            const [ __FUNNAME, __LOCATION ] = __LINE.split('@', 2);
+            const __NAMELINE = getValue(__LOCATION, "").replace(/.*\//, ""); 
+
+            if (countCaller-- > 0) {
+                // Aufrufer wird ignoriert...
+                continue;
+            }
+
+            if (ignoreLibs && __NAMELINE.match(/^lib\./)) {  // "lib.*"
+                if (! ret) {
+                    [ ret, nameLine, funName ] = [ __LOCATION, __NAMELINE, __FUNNAME ];
+                }
+                continue;
+            }
+            [ ret, nameLine, funName ] = [ __LOCATION, __NAMELINE, __FUNNAME ];
+            break;
+        }
+
+        if (ret && ! longForm) {
+            ret = nameLine;
+        }
+
+        return ret + (showFunName ? (':' + funName) : "");
+    } catch (ex) {
+        return showException("Error in codeLine()", ex);
+    }
+}
+
 // ==================== Ende Abschnitt fuer Debugging, Error-Handling ====================
 
 // *** EOF ***

--- a/misc/OS2/lib/util.option.data.js
+++ b/misc/OS2/lib/util.option.data.js
@@ -183,7 +183,7 @@ function setOptValue(opt, value) {
 function getOptValue(opt, defValue = undefined) {
     let value;
 
-    if (opt && opt.Loaded) {
+    if (opt /*&& opt.Loaded*/) {  // NOTE opt.Loaded steuert das Laden, aber opt.Value den Wert
         value = getValue(opt.Value, defValue);
     }
 

--- a/misc/OS2/lib/util.proto.js
+++ b/misc/OS2/lib/util.proto.js
@@ -115,7 +115,7 @@ Object.defineProperty(Array.prototype, 'Reduce', {
     'enumerable'      : false,
     'value'           : function(reduceFun, value) {
         if ((! reduceFun) || ((typeof reduceFun) !== 'function')) {
-            throw TypeError();
+            throw TypeError("Invalid reduce() function!");
         }
 
         const __LEN = this.length;
@@ -146,7 +146,7 @@ Object.defineProperty(Array.prototype, 'ReduceRight', {
     'enumerable'      : false,
     'value'           : function(reduceFun, value) {
         if ((! reduceFun) || ((typeof reduceFun) !== 'function')) {
-            throw TypeError();
+            throw TypeError("Invalid reduceRight() function!");
         }
 
         const __LEN = this.length;

--- a/misc/OS2/test/util.option.api.test.js
+++ b/misc/OS2/test/util.option.api.test.js
@@ -24,11 +24,32 @@
 // ==================== Abschnitt Operationen auf Optionen ====================
 
     const __TESTDATA = {
-            'prefixName'    : [ "Name", "Prefix",   "PrefixName"    ],
-            'postfixName'   : [ "Name", "Postfix",  "NamePostfix"   ]
+            'prefixName'    : [ "Name",     "Prefix",   "PrefixName"                        ],
+            'postfixName'   : [ "Name",     "Postfix",  "NamePostfix"                       ],
+            'loadOption'    : [ "saison",   42,         17,             false,  undefined   ],
         };
 
     new UnitTestOption('util.option.api', "Schnittstelle zur Behandlung von Optionen", {
+            'loadOption'          : function() {
+                                        const [ __NAME, , __EXP ] = __TESTDATA['loadOption'];
+                                        const __OPT = this.optSet[__NAME];
+
+                                        return callPromiseChain(invalidateOpt(__OPT, true, false), () => loadOption(__OPT, false), value => {
+                                                const __RET = value;
+
+                                                return ASSERT_EQUAL(__RET, __EXP, "loadOption($[" + __LOG.info(__NAME, false) + "]) sollte die aktuelle Saison liefern");
+                                            });
+                                    },
+            'loadOptionForce'     : function() {
+                                        const [ __NAME, , __EXP ] = __TESTDATA['loadOption'];
+                                        const __OPT = this.optSet[__NAME];
+
+                                        return callPromiseChain(invalidateOpt(__OPT, true, false), () => loadOption(__OPT, true), value => {
+                                                const __RET = value;
+
+                                                return ASSERT_EQUAL(__RET, __EXP, "loadOption($[" + __LOG.info(__NAME, false) + "]) sollte die aktuelle Saison liefern");
+                                            });
+                                    },
             'prefixName'          : function() {
                                         const [ __NAME, __PREFIX, __EXP ] = __TESTDATA['prefixName'];
 
@@ -42,6 +63,53 @@
                                         const __RET = postfixName(__NAME, __POSTFIX);
 
                                         return ASSERT_EQUAL(__RET, __EXP, "Name falsch zusammengesetzt");
+                                    },
+            'resetOptions'        : async function() {
+                                        const [ __NAME, __VAL, __EXP, __RELOAD ] = __TESTDATA['loadOption'];
+                                        const __OPT = this.optSet[__NAME];
+
+                                        await callPromiseChain(new Promise(function(resolve, reject) { return setOpt(__OPT, __VAL, __RELOAD, resolve, reject); }), () => getOptValue(__OPT), value => {
+                                                const __RET = value;
+
+                                                return ASSERT_EQUAL(__RET, __VAL, "getOptValue($[" + __LOG.info(__NAME, false) + "]) sollte die gesetzte Saison liefern");
+                                            });
+
+                                        return callPromiseChain(resetOptions(this.optSet, __RELOAD), () => getOptValue(__OPT), value => {
+                                                const __RET = value;
+
+                                                return ASSERT_EQUAL(__RET, __EXP, "getOptValue($[" + __LOG.info(__NAME, false) + "]) sollte die Default-Saison liefern");
+                                            });
+                                    },
+            'loadOptValue'        : function() {
+                                        const [ __NAME, , __EXP ] = __TESTDATA['loadOption'];
+                                        const __OPT = this.optSet[__NAME];
+
+                                        return callPromiseChain(loadOptValue(__OPT), value => {
+                                                const __RET = value;
+
+                                                return ASSERT_EQUAL(__RET, __EXP, "loadOption($[" + __LOG.info(__NAME, false) + "]) sollte die aktuelle Saison liefern");
+                                            });
+                                    },
+            'loadOptValueDefault' : function() {
+                                        const [ __NAME, , __EXP, __RELOAD, __ALT ] = __TESTDATA['loadOption'];
+                                        const __OPT = this.optSet[__NAME];
+
+                                        return callPromiseChain(new Promise(function(resolve, reject) { return setOpt(__OPT, __ALT, __RELOAD, resolve, reject); }), () => loadOptValue(__OPT, __EXP), value => {
+                                                const __RET = value;
+
+                                                return ASSERT_EQUAL(__RET, __EXP, "loadOption($[" + __LOG.info(__NAME, false) + "]) sollte die aktuelle Saison liefern");
+                                            });
+                                    },
+            'loadOptValueSync'    : function() {
+                                        const [ __NAME, , __EXP, , __ALT ] = __TESTDATA['loadOption'];
+                                        const __ASYNC = false;
+                                        const __OPT = this.optSet[__NAME];
+
+                                        return callPromiseChain(Promise.resolve(loadOptValue(__OPT, __ALT, __ASYNC)), value => {
+                                                const __RET = value;
+
+                                                return ASSERT_EQUAL(__RET, __EXP, "loadOption($[" + __LOG.info(__NAME, false) + "]) sollte die aktuelle Saison liefern");
+                                            });
                                     }
         });
 


### PR DESCRIPTION
test.lib.option.js/UnitTestOption(): Auf- und Abbau realer Optionen
util.option.api.test.js: 6 weitere Unit-Tests zu Optionen (API)
util.option.api.js/checkOpt(): Überprüfung von opt auf Options-Objekt
invalidateOpt(): Invalidieren von nicht nachgeladenen Optionen (!Loaded)
getOptValue(): Auch die "Werte" von nicht geladenen Optionen (undefined)
util.proto.js/Reduce()+ReduceRight(): TypeError genauer spezifiziert
util.debug.js/codeLine() - Ermittlung der Stelle im Quellcode
callPromiseChain(): Extrem hilfreich! Typüberprüfung der Parameter
