### PR TITLE
Bugfix promptNextOptByName(), codeLine() in Unit-Tests, 2 Unit-Tests

### DIFF
--- a/misc/OS2/lib/test.assert.js
+++ b/misc/OS2/lib/test.assert.js
@@ -141,11 +141,13 @@ const ASSERT = function(test, whatFailed, msg, thisArg, ...params) {
 
     if (! test) {
         const __FAIL = new AssertionFailed(whatFailed, msg, thisArg, ...params);
+
+        __FAIL.codeLine = codeLine(false, true, 2, true);
         __LOG[4]("FAIL", __LOG.info(__FAIL, true, true));
 
         throw __FAIL;
     } else {
-        __LOG[8]("OK", test);
+        __LOG[8]("OK", test, codeLine(false, true, 2, false), "(NOT " + whatFailed + ')');
     }
 
     return true;
@@ -268,7 +270,7 @@ const ASSERT_OFTYPE = function(obj, type, msg, thisArg, ...params) {
 }
 
 const ASSERT_NOT_OFTYPE = function(obj, type, msg, thisArg, ...params) {
-    return ASSERT_NOT((typeOf(obj) === type), __LOG.info(obj, true, true) + " ist " + __LOG.info(type, false), msg, thisArg, ...params);
+    return ASSERT((typeOf(obj) !== type), __LOG.info(obj, true, true) + " ist " + __LOG.info(type, false), msg, thisArg, ...params);
 }
 
 const ASSERT_TYPEOF = function(obj, type, msg, thisArg, ...params) {
@@ -276,7 +278,7 @@ const ASSERT_TYPEOF = function(obj, type, msg, thisArg, ...params) {
 }
 
 const ASSERT_NOT_TYPEOF = function(obj, type, msg, thisArg, ...params) {
-    return ASSERT_NOT(((typeof obj) === type), __LOG.info(obj, true, true) + " ist " + __LOG.info(type, false), msg, thisArg, ...params);
+    return ASSERT(((typeof obj) !== type), __LOG.info(obj, true, true) + " ist " + __LOG.info(type, false), msg, thisArg, ...params);
 }
 
 const ASSERT_INSTANCEOF = function(obj, cls, msg, thisArg, ...params) {
@@ -288,7 +290,7 @@ const ASSERT_INSTANCEOF = function(obj, cls, msg, thisArg, ...params) {
 const ASSERT_NOT_INSTANCEOF = function(obj, cls, msg, thisArg, ...params) {
     const __CLASSNAME = (cls || { }).name;
 
-    return ASSERT_NOT((obj instanceof cls), __LOG.info(obj, true, true) + " ist " + __LOG.info(__CLASSNAME, false), msg, thisArg, ...params);
+    return ASSERT(! (obj instanceof cls), __LOG.info(obj, true, true) + " ist " + __LOG.info(__CLASSNAME, false), msg, thisArg, ...params);
 }
 
 const ASSERT_MATCH = function(str, pattern, msg, thisArg, ...params) {
@@ -296,7 +298,7 @@ const ASSERT_MATCH = function(str, pattern, msg, thisArg, ...params) {
 }
 
 const ASSERT_NOT_MATCH = function(str, pattern, msg, thisArg, ...params) {
-    return ASSERT_NOT((str || "").match(pattern), __LOG.info(str, true, true) + " hat das Muster " + String(pattern), msg, thisArg, ...params);
+    return ASSERT(! (str || "").match(pattern), __LOG.info(str, true, true) + " hat das Muster " + String(pattern), msg, thisArg, ...params);
 }
 
 // ==================== Ende Abschnitt fuer sonstige ASSERT-Funktionen ====================

--- a/misc/OS2/lib/test.class.unittest.js
+++ b/misc/OS2/lib/test.class.unittest.js
@@ -311,6 +311,7 @@ UnitTest.defaultResultFun = function(resultObj, tableId, doc = document) {
             appendCell(__ROW, __RESULTS.countException);
             appendCell(__ROW, __RESULTS.countError);
             appendCell(__ROW, __RESULTS.result);
+            appendCell(__ROW, __RESULTS.codeLine);
         }
 
         setRowStyle(__ROW, __STYLE);
@@ -344,6 +345,7 @@ UnitTest.getOrCreateTestResultTable = function(tableId = 'UnitTest', doc = docum
         appendCell(__ROW, "EX", __COLOR);
         appendCell(__ROW, "ERR", __COLOR);
         appendCell(__ROW, "Ergebnis", __COLOR);
+        appendCell(__ROW, "Quellcode", __COLOR);
 
         table.appendChild(__ROW);
     }
@@ -423,10 +425,12 @@ Class.define(UnitTestResults, Object, {
 
                                             if (__EX instanceof AssertionFailed) {
                                                 this.result = __EX.getTextMessage();
+                                                this.codeLine = __EX.codeLine;
 
                                                 return this.failed();
                                             } else {
                                                 this.result = String(__EX);
+                                                this.codeLine = codeLineFor(__EX, false, true, false, true);
 
                                                 return ++this.countException;
                                             }
@@ -435,6 +439,7 @@ Class.define(UnitTestResults, Object, {
                                             const __EX = (ex || { });
 
                                             this.result = __EX.message;
+                                            this.codeLine = codeLineFor(__EX, false, true, false, true);
 
                                             return ++this.countError;
                                         },
@@ -472,6 +477,13 @@ Class.define(UnitTestResults, Object, {
                                             }
                                             this.results[resultsToAdd.name] = resultsToAdd.results;
 
+                                            if (! this.codeLines) {
+                                                this.codeLines = { };
+                                            }
+                                            if (resultsToAdd.codeLines) {
+                                                this.codeLines[resultsToAdd.name] = resultsToAdd.codeLines;
+                                            }
+
                                             return this;
                                         },
                 'sum'                 : function() {
@@ -484,7 +496,8 @@ Class.define(UnitTestResults, Object, {
                                                     'exception' : this.countException,
                                                     'error'     : this.countError,
                                                     'tests'     : this.test.tDefs,
-                                                    'results'   : this.results
+                                                    'results'   : this.results,
+                                                    'codeLines' : this.codeLines
                                                 };
                                         }
             });

--- a/misc/OS2/lib/util.debug.js
+++ b/misc/OS2/lib/util.debug.js
@@ -67,14 +67,15 @@ function defaultCatch(error, show) {
 }
 
 // Ermittlung der gerade signifikanten Quellcode-Stelle des Programmablaufs
+// ex: Exception, Error o.ae. mit 'stack' Eigenschaft, die ein Stacktrace enthaelt
 // longForm: Ausgabe des vollen Pfades anstelle von nur dem Dateinamen und der Zeilennummer
 // showFunName: Neben Datei und Zeilennummer zusaetzlich Funktionsnamen zurueckgeben (Default: false)
 // ignoreCaller: Neben codeLine() auch den Caller ignorieren, als Zahl: Anzahl der Caller (Default: false)
 // ignoreLibs (empfohlen): Ueberspringen von lib*.js-Eintraegen (ausser beim untersten Aufruf)
 // return Liefert Dateiname:Zeilennummer des Aufrufers als String
-function codeLine(longForm = false, showFunName = false, ignoreCaller = false, ignoreLibs = true) {
+function codeLineFor(ex, longForm = false, showFunName = false, ignoreCaller = false, ignoreLibs = true) {
     try {
-        const __STACK = Error().stack.split("\n");
+        const __STACK = (ex || { stack : "" }).stack.split("\n");
         let countCaller = Number(ignoreCaller);  // Normalerweise 0 oder 1, bei 2 wird auch der naechste Aufrufer ignoriert!
         let ret;
         let nameLine;
@@ -109,6 +110,18 @@ function codeLine(longForm = false, showFunName = false, ignoreCaller = false, i
     } catch (ex) {
         return showException("Error in codeLine()", ex);
     }
+}
+
+// Ermittlung der gerade signifikanten Quellcode-Stelle des Programmablaufs
+// longForm: Ausgabe des vollen Pfades anstelle von nur dem Dateinamen und der Zeilennummer
+// showFunName: Neben Datei und Zeilennummer zusaetzlich Funktionsnamen zurueckgeben (Default: false)
+// ignoreCaller: Neben codeLine() auch den Caller ignorieren, als Zahl: Anzahl der Caller (Default: false)
+// ignoreLibs (empfohlen): Ueberspringen von lib*.js-Eintraegen (ausser beim untersten Aufruf)
+// return Liefert Dateiname:Zeilennummer des Aufrufers als String
+function codeLine(longForm = false, showFunName = false, ignoreCaller = false, ignoreLibs = true) {
+    const __EX = Error();
+
+    return codeLineFor(__EX, longForm, showFunName, ignoreCaller, ignoreLibs);
 }
 
 // ==================== Ende Abschnitt fuer Debugging, Error-Handling ====================

--- a/misc/OS2/lib/util.option.data.js
+++ b/misc/OS2/lib/util.option.data.js
@@ -285,7 +285,7 @@ function promptNextOpt(opt, value = undefined, reload = false, freeValue = false
             }
 
             if (nextVal !== __VALUE) {
-                if (nextVal) {
+                if (nextVal !== undefined) {
                     return setOpt(opt, nextVal, reload, onFulfilled, onRejected);
                 }
 
@@ -294,7 +294,11 @@ function promptNextOpt(opt, value = undefined, reload = false, freeValue = false
                 showAlert(__LABEL, "Ung\xFCltige Eingabe: " + __ANSWER);
             }
         }
+
+        onFulfilled(__VALUE);
     } catch (ex) {
+        onRejected(ex);
+
         showException('[' + (ex && ex.lineNumber) + "] promptNextOpt()", ex);
     }
 

--- a/misc/OS2/lib/util.option.run.js
+++ b/misc/OS2/lib/util.option.run.js
@@ -43,22 +43,24 @@ function initOptAction(optAction, item = undefined, optSet = undefined, optConfi
         const __RELOAD = getValue(getValue(__CONFIG, { }).ActionReload, true);
 
         switch (optAction) {
-        case __OPTACTION.SET : fun = function() {
-                                       return setOptByName(optSet, item, __CONFIG.SetValue, __RELOAD).catch(defaultCatch);
-                                   };
-                               break;
-        case __OPTACTION.NXT : fun = function() {
-                                       return promptNextOptByName(optSet, item, __CONFIG.SetValue, __RELOAD,
-                                                  __CONFIG.FreeValue, __CONFIG.SelValue, __CONFIG.MinChoice).catch(defaultCatch);
-                                   };
-                               break;
-        case __OPTACTION.RST : fun = function() {
-                                       return resetOptions(optSet, __RELOAD).then(
-                                               result => __LOG[4]("RESETTING (" + result + ")..."),
-                                               defaultCatch);
-                                   };
-                               break;
-        default :              break;
+        case __OPTACTION.SET  : fun = function() {
+                                        return setOptByName(optSet, item, __CONFIG.SetValue, __RELOAD).catch(defaultCatch);
+                                    };
+                                break;
+        case __OPTACTION.NXT  : fun = async function() {
+                                        return new Promise(function(resolve, reject) {
+                                                return promptNextOptByName(optSet, item, __CONFIG.SetValue, __RELOAD,
+                                                    __CONFIG.FreeValue, __CONFIG.SelValue, __CONFIG.MinChoice, resolve, reject);
+                                            }).catch(defaultCatch);
+                                    };
+                                break;
+        case __OPTACTION.RST  : fun = function() {
+                                        return resetOptions(optSet, __RELOAD).then(
+                                                result => __LOG[4]("RESETTING (" + result + ")..."),
+                                                defaultCatch);
+                                    };
+                                break;
+        default :               break;
         }
     }
 

--- a/misc/OS2/test/util.store.test.js
+++ b/misc/OS2/test/util.store.test.js
@@ -1945,12 +1945,69 @@
 // ==================== Abschnitt fuer die Sicherung von Daten mit Callback ====================
 
     new UnitTest('util.store.js Callback', "Sicherung von Daten mit Callback", {
-//            'setStored'           : function() {
-//                                    }
-        });
+            'setStored'           : function() {
+                                        const [ __NAME, __VAL ] = __TESTDATA['Object2'];
+                                        const __RELOAD = false;
+                                        const __SERIAL = false;
 
-//function setStored(name, value, reload = false, serial = false, onFulfilled = undefined, onRejected = undefined) {
-//function setNextStored(arr, name, value, reload = false, serial = false, onFulfilled = undefined, onRejected = undefined) {
+                                        return callPromiseChain(new Promise(function(resolve, reject) { return setStored(__NAME, __VAL, __RELOAD, __SERIAL, resolve, reject); }), () => summonValue(__NAME, __ERROR), value => {
+                                                const __RET = value;
+
+                                                return ASSERT_EQUAL(__RET, __VAL, "Object falsch geladen");
+                                            });
+                                    },
+            'setStoredSerial'     : function() {
+                                        const [ __NAME, __VAL ] = __TESTDATA['Object2'];
+                                        const __RELOAD = false;
+                                        const __SERIAL = true;
+
+                                        return callPromiseChain(new Promise(function(resolve, reject) { return setStored(__NAME, __VAL, __RELOAD, __SERIAL, resolve, reject); }), () => deserialize(__NAME, __ERROR), value => {
+                                                const __RET = value;
+
+                                                return ASSERT_EQUAL(__RET, __VAL, "Object falsch geladen");
+                                            });
+                                    },
+            'setNextStored'       : async function() {
+                                        const [ __NAME, __VAL ] = __TESTDATA['Int'];
+                                        const __ARR = [ 1, 2, 4, 8, 42, 47.11 ];
+                                        const __EXP1 = 47.11;
+                                        const __EXP2 = 1;
+                                        const __RELOAD = false;
+                                        const __SERIAL = false;
+
+                                        await callPromiseChain(new Promise(function(resolve, reject) { return setNextStored(__ARR, __NAME, __VAL, __RELOAD, __SERIAL, resolve, reject); }), () => summonValue(__NAME, __ERROR), value => {
+                                                const __RET = value;
+
+                                                return ASSERT_EQUAL(__RET, __EXP1, "Object falsch geladen");
+                                            });
+
+                                        return callPromiseChain(new Promise(function(resolve, reject) { return setNextStored(__ARR, __NAME, __EXP1, __RELOAD, __SERIAL, resolve, reject); }), () => summonValue(__NAME, __ERROR), value => {
+                                                const __RET = value;
+
+                                                return ASSERT_EQUAL(__RET, __EXP2, "Object falsch geladen");
+                                            });
+                                    },
+            'setNextStoredSerial' : async function() {
+                                        const [ __NAME, __VAL ] = __TESTDATA['Int'];
+                                        const __ARR = [ 1, 2, 4, 8, 42, 47.11 ];
+                                        const __EXP1 = 47.11;
+                                        const __EXP2 = 1;
+                                        const __RELOAD = false;
+                                        const __SERIAL = true;
+
+                                        await callPromiseChain(new Promise(function(resolve, reject) { return setNextStored(__ARR, __NAME, __VAL, __RELOAD, __SERIAL, resolve, reject); }), () => deserialize(__NAME, __ERROR), value => {
+                                                const __RET = value;
+
+                                                return ASSERT_EQUAL(__RET, __EXP1, "Object falsch geladen");
+                                            });
+
+                                        return callPromiseChain(new Promise(function(resolve, reject) { return setNextStored(__ARR, __NAME, __EXP1, __RELOAD, __SERIAL, resolve, reject); }), () => deserialize(__NAME, __ERROR), value => {
+                                                const __RET = value;
+
+                                                return ASSERT_EQUAL(__RET, __EXP2, "Object falsch geladen");
+                                            });
+                                    }
+        });
 
 // ==================== Ende Abschnitt fuer die Sicherung und das Laden von Daten ====================
 


### PR DESCRIPTION
Bugfix: Nutzung promptNextOptByName() mit Promise (Menüauswahl)
codeLineFor() - Erweiterung für beliebige (auch alte) Stacktraces
test.assert.js: Einbau der codeLine() in ASSERTs
test.class.unittest.js: Einbau der codeLine() in Unit-Tests
util.store.test.js: 2 Unit-Tests zu setStored() / Testmodul nicht leer

