### PR TITLE
Main/PageManager-Framework: Bugfixes und Einbau in die Haupt-Skripte

### DIFF
--- a/misc/OS2/index.html
+++ b/misc/OS2/index.html
@@ -184,6 +184,7 @@
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.option.page.node.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.option.page.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.option.run.js
+// @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.main.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/OS2.list.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/OS2.team.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/OS2.page.team.js
@@ -241,6 +242,7 @@
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.option.page.node.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.option.page.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.option.run.js
+// @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.main.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/OS2.list.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/OS2.team.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/OS2.page.team.js
@@ -294,6 +296,7 @@
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.option.page.node.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.option.page.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.option.run.js
+// @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.main.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/OS2.list.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/OS2.team.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/OS2.page.team.js
@@ -349,6 +352,7 @@
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.option.page.node.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.option.page.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.option.run.js
+// @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.main.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/OS2.list.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/OS2.team.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/OS2.page.team.js
@@ -417,6 +421,7 @@
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.option.page.node.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.option.page.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.option.run.js
+// @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.main.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/OS2.list.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/OS2.team.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/OS2.page.team.js
@@ -502,6 +507,7 @@
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.option.page.node.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.option.page.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.option.run.js
+// @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.main.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/OS2.list.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/OS2.team.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/OS2.page.team.js
@@ -556,6 +562,7 @@
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.option.page.node.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.option.page.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.option.run.js
+// @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.main.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/OS2.list.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/OS2.team.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/OS2.page.team.js
@@ -614,6 +621,7 @@
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.option.page.node.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.option.page.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.option.run.js
+// @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.main.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/OS2.list.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/OS2.team.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/OS2.page.team.js
@@ -673,6 +681,7 @@
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.option.page.node.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.option.page.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.option.run.js
+// @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.main.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/OS2.list.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/OS2.team.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/OS2.page.team.js
@@ -745,6 +754,7 @@
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.option.page.node.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.option.page.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.option.run.js
+// @require      https://eselce.github.io/GitTest/misc/OS2/lib/util.main.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/OS2.list.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/OS2.team.js
 // @require      https://eselce.github.io/GitTest/misc/OS2/lib/OS2.page.team.js

--- a/misc/OS2/lib/OS2.class.table.js
+++ b/misc/OS2/lib/OS2.class.table.js
@@ -20,7 +20,7 @@
     constructor*/(optSet, colIdx, rows, offsetUpper, offsetLower) {
         'use strict';
 
-        Object.call(this);
+        //Object.call(this);
 
         this.currSaison = getOptValue(optSet.aktuelleSaison);
 

--- a/misc/OS2/lib/OS2.page.js
+++ b/misc/OS2/lib/OS2.page.js
@@ -25,9 +25,9 @@ function getPageIdFromURL(url, leafs, item = 'page') {
 
     for (let leaf in leafs) {
         if (__LEAF === leaf) {
-            const __DEFAULT = leafs[leaf];
+            const __BASE = leafs[leaf];
 
-            return getValue(__URI.getQueryPar(item), __DEFAULT);
+            return __BASE + getValue(__URI.getQueryPar(item), 0);
         }
     }
 

--- a/misc/OS2/lib/index.html
+++ b/misc/OS2/lib/index.html
@@ -372,7 +372,8 @@ const __BUILDLIB = (async (libNumber) => {
             'util.option.page.action',
             'util.option.page.node',
             'util.option.page',
-            'util.option.run'
+            'util.option.run',
+            'util.main'
         ];
     const __LIBSOS2BASE = [
             'OS2.list',

--- a/misc/OS2/lib/test.assert.js
+++ b/misc/OS2/lib/test.assert.js
@@ -22,7 +22,7 @@
 // funs: Liste oder Array von Funktionen, die jeweils das Zwischenergebnis umwandeln
 // throw Wirft im Fehlerfall eine AssertionFailed-Exception
 // return Ein Promise-Objekt mit dem Endresultat
-async function callPromiseChain(startValue, ...funs) {
+async function callPromiseChain(startValue, ... funs) {
     if (startValue !== undefined) {
         if (((typeof startValue) !== 'object') || ! (startValue instanceof Promise)) {
             throw TypeError("callPromiseChain(): startValue should be a Promise!");
@@ -46,7 +46,7 @@ async function callPromiseChain(startValue, ...funs) {
 // promises: Liste oder Array von Promises oder Werten
 // throw Wirft im Fehlerfall eine AssertionFailed-Exception
 // return Ein Promise-Objekt mit einem Array von Einzelergebnissen als Endresultat
-async function callPromiseArray(...promises) {
+async function callPromiseArray(... promises) {
     return Promise.all(promises.flat(1).map((val, idx, arr) => Promise.resolve(val).catch(ex => assertionCatch(ex, {
             'promise'   : value,
             'array'     : arr,
@@ -65,14 +65,14 @@ async function callPromiseArray(...promises) {
 // params: ggfs. Parameter fuer die msg-Funktion
 
 /*class*/ function AssertionFailed /*{
-    constructor*/(whatFailed, msg, thisArg, ...params) {
+    constructor*/(whatFailed, msg, thisArg, ... params) {
         //'use strict';
         const __THIS = (thisArg || this);
 
         if (msg === undefined) {
             this.message = "";
         } else if ((typeof msg) === 'function') {
-            const __TEXT = msg.call(__THIS, ...params);
+            const __TEXT = msg.apply(__THIS, params);
 
             this.message = String(__TEXT);
         } else {
@@ -100,13 +100,13 @@ Class.define(AssertionFailed, Object, {
 // error: Parameter von reject() im Promise-Objekt, der von Promise.catch() erhalten wurde
 // attribs: Weitere Attribute in Objekten, die im error vermerkt werden
 // return Liefert eine Assertion und die showAlert()-Parameter zurueck
-function assertionCatch(error, ...attribs) {
+function assertionCatch(error, ... attribs) {
     // Sichern, dass error belegt ist (wie etwa bei GMs 'reject();' in 'GM_setValue())'...
     error = (error || new Error("Promise rejected!"));
 
     try {
         const __LABEL = `[${error.lineNumber}] ${__DBMOD.Name}`;
-        const __ERROR = Object.assign(error, ...attribs);
+        const __ERROR = Object.assign(error, ... attribs);
         const __RET = showException(__LABEL, __ERROR, false);
 
         UNUSED(__RET);
@@ -136,11 +136,11 @@ function assertionCatch(error, ...attribs) {
 // params: ggfs. Parameter fuer die msg-Funktion
 // throw Wirft dann AssertionFailed-Exception mit diesem Text
 // return true, da in diesem Fall keine Exception geworfen wurde!
-const ASSERT = function(test, whatFailed, msg, thisArg, ...params) {
+const ASSERT = function(test, whatFailed, msg, thisArg, ... params) {
     //'use strict';
 
     if (! test) {
-        const __FAIL = new AssertionFailed(whatFailed, msg, thisArg, ...params);
+        const __FAIL = new AssertionFailed(whatFailed, msg, thisArg, ... params);
 
         __FAIL.codeLine = codeLine(false, true, 2, true);
         __LOG[4]("FAIL", __LOG.info(__FAIL, true, true));
@@ -161,144 +161,144 @@ const ASSERT = function(test, whatFailed, msg, thisArg, ...params) {
 // params: ggfs. Parameter fuer die msg-Funktion
 // throw Wirft dann AssertionFailed-Exception mit diesem Text
 // return true, da in diesem Fall keine Exception geworfen wurde!
-const ASSERT_NOT = function(test, whatFailed, msg, thisArg, ...params) {
-    return ASSERT(! test, whatFailed, msg, thisArg, ...params);
+const ASSERT_NOT = function(test, whatFailed, msg, thisArg, ... params) {
+    return ASSERT(! test, whatFailed, msg, thisArg, ... params);
 }
 
 // ==================== Ende Abschnitt fuer ASSERT ====================
 
 // ==================== Abschnitt fuer sonstige ASSERT-Funktionen ====================
 
-const ASSERT_TRUE = function(test, msg, thisArg, ...params) {
-    return ASSERT(test, "false", msg, thisArg, ...params);
+const ASSERT_TRUE = function(test, msg, thisArg, ... params) {
+    return ASSERT(test, "false", msg, thisArg, ... params);
 }
 
-const ASSERT_FALSE = function(test, msg, thisArg, ...params) {
-    return ASSERT(! test, "true", msg, thisArg, ...params);
+const ASSERT_FALSE = function(test, msg, thisArg, ... params) {
+    return ASSERT(! test, "true", msg, thisArg, ... params);
 }
 
-const ASSERT_NULL = function(test, msg, thisArg, ...params) {
-    return ASSERT(test === null, __LOG.info(test, true, true) + " !== null", msg, thisArg, ...params);
+const ASSERT_NULL = function(test, msg, thisArg, ... params) {
+    return ASSERT(test === null, __LOG.info(test, true, true) + " !== null", msg, thisArg, ... params);
 }
 
-const ASSERT_NOT_NULL = function(test, msg, thisArg, ...params) {
-    return ASSERT(test !== null, __LOG.info(test, true, true) + " === null", msg, thisArg, ...params);
+const ASSERT_NOT_NULL = function(test, msg, thisArg, ... params) {
+    return ASSERT(test !== null, __LOG.info(test, true, true) + " === null", msg, thisArg, ... params);
 }
 
-const ASSERT_ZERO = function(test, msg, thisArg, ...params) {
-    return ASSERT(test === 0, __LOG.info(test, true, true) + " !== 0", msg, thisArg, ...params);
+const ASSERT_ZERO = function(test, msg, thisArg, ... params) {
+    return ASSERT(test === 0, __LOG.info(test, true, true) + " !== 0", msg, thisArg, ... params);
 }
 
-const ASSERT_NOT_ZERO = function(test, msg, thisArg, ...params) {
-    return ASSERT(test !== 0, __LOG.info(test, true, true) + " === 0", msg, thisArg, ...params);
+const ASSERT_NOT_ZERO = function(test, msg, thisArg, ... params) {
+    return ASSERT(test !== 0, __LOG.info(test, true, true) + " === 0", msg, thisArg, ... params);
 }
 
-const ASSERT_ONE = function(test, msg, thisArg, ...params) {
-    return ASSERT(test === 1, __LOG.info(test, true, true) + " !== 1", msg, thisArg, ...params);
+const ASSERT_ONE = function(test, msg, thisArg, ... params) {
+    return ASSERT(test === 1, __LOG.info(test, true, true) + " !== 1", msg, thisArg, ... params);
 }
 
-const ASSERT_NOT_ONE = function(test, msg, thisArg, ...params) {
-    return ASSERT(test !== 1, __LOG.info(test, true, true) + " === 1", msg, thisArg, ...params);
+const ASSERT_NOT_ONE = function(test, msg, thisArg, ... params) {
+    return ASSERT(test !== 1, __LOG.info(test, true, true) + " === 1", msg, thisArg, ... params);
 }
 
-const ASSERT_SET = function(test, msg, thisArg, ...params) {
-    return ASSERT(test != undefined, __LOG.info(test, true, true) + " == undefined", msg, thisArg, ...params);
+const ASSERT_SET = function(test, msg, thisArg, ... params) {
+    return ASSERT(test != undefined, __LOG.info(test, true, true) + " == undefined", msg, thisArg, ... params);
 }
 
-const ASSERT_NOT_SET = function(test, msg, thisArg, ...params) {
-    return ASSERT(test == undefined, __LOG.info(test, true, true) + " != undefined", msg, thisArg, ...params);
+const ASSERT_NOT_SET = function(test, msg, thisArg, ... params) {
+    return ASSERT(test == undefined, __LOG.info(test, true, true) + " != undefined", msg, thisArg, ... params);
 }
 
-const ASSERT_EQUAL = function(erg, exp, msg, thisArg, ...params) {
-    return ASSERT(__LOG.info(erg, true, true) === __LOG.info(exp, true, true), __LOG.info(erg, true, true) + " !== " + __LOG.info(exp, true, true), msg, thisArg, ...params);
+const ASSERT_EQUAL = function(erg, exp, msg, thisArg, ... params) {
+    return ASSERT(__LOG.info(erg, true, true) === __LOG.info(exp, true, true), __LOG.info(erg, true, true) + " !== " + __LOG.info(exp, true, true), msg, thisArg, ... params);
 }
 
-const ASSERT_NOT_EQUAL = function(erg, exp, msg, thisArg, ...params) {
-    return ASSERT(__LOG.info(erg, true, true) !== __LOG.info(exp, true, true), __LOG.info(erg, true, true) + " === " + __LOG.info(exp, true, true), msg, thisArg, ...params);
+const ASSERT_NOT_EQUAL = function(erg, exp, msg, thisArg, ... params) {
+    return ASSERT(__LOG.info(erg, true, true) !== __LOG.info(exp, true, true), __LOG.info(erg, true, true) + " === " + __LOG.info(exp, true, true), msg, thisArg, ... params);
 }
 
-const ASSERT_ALIKE = function(erg, exp, msg, thisArg, ...params) {
-    return ASSERT(erg == exp, __LOG.info(erg, true, true) + " != " + __LOG.info(exp, true, true), msg, thisArg, ...params);
+const ASSERT_ALIKE = function(erg, exp, msg, thisArg, ... params) {
+    return ASSERT(erg == exp, __LOG.info(erg, true, true) + " != " + __LOG.info(exp, true, true), msg, thisArg, ... params);
 }
 
-const ASSERT_NOT_ALIKE = function(erg, exp, msg, thisArg, ...params) {
-    return ASSERT(erg != exp, __LOG.info(erg, true, true) + " == " + __LOG.info(exp, true, true), msg, thisArg, ...params);
+const ASSERT_NOT_ALIKE = function(erg, exp, msg, thisArg, ... params) {
+    return ASSERT(erg != exp, __LOG.info(erg, true, true) + " == " + __LOG.info(exp, true, true), msg, thisArg, ... params);
 }
 
-const ASSERT_LESS = function(erg, exp, msg, thisArg, ...params) {
-    return ASSERT(erg < exp, __LOG.info(erg, true, true) + " >= " + __LOG.info(exp, true, true), msg, thisArg, ...params);
+const ASSERT_LESS = function(erg, exp, msg, thisArg, ... params) {
+    return ASSERT(erg < exp, __LOG.info(erg, true, true) + " >= " + __LOG.info(exp, true, true), msg, thisArg, ... params);
 }
 
-const ASSERT_NOT_LESS = function(erg, exp, msg, thisArg, ...params) {
-    return ASSERT(erg >= exp, __LOG.info(erg, true, true) + " < " + __LOG.info(exp, true, true), msg, thisArg, ...params);
+const ASSERT_NOT_LESS = function(erg, exp, msg, thisArg, ... params) {
+    return ASSERT(erg >= exp, __LOG.info(erg, true, true) + " < " + __LOG.info(exp, true, true), msg, thisArg, ... params);
 }
 
-const ASSERT_GREATER = function(erg, exp, msg, thisArg, ...params) {
-    return ASSERT(erg > exp, __LOG.info(erg, true, true) + " <= " + __LOG.info(exp, true, true), msg, thisArg, ...params);
+const ASSERT_GREATER = function(erg, exp, msg, thisArg, ... params) {
+    return ASSERT(erg > exp, __LOG.info(erg, true, true) + " <= " + __LOG.info(exp, true, true), msg, thisArg, ... params);
 }
 
-const ASSERT_NOT_GREATER = function(erg, exp, msg, thisArg, ...params) {
-    return ASSERT(erg <= exp, __LOG.info(erg, true, true) + " > " + __LOG.info(exp, true, true), msg, thisArg, ...params);
+const ASSERT_NOT_GREATER = function(erg, exp, msg, thisArg, ... params) {
+    return ASSERT(erg <= exp, __LOG.info(erg, true, true) + " > " + __LOG.info(exp, true, true), msg, thisArg, ... params);
 }
 
-const ASSERT_IN_DELTA = function(erg, exp, delta, msg, thisArg, ...params) {
-    return ASSERT(Math.abs(erg - exp) <= delta, __LOG.info(erg, true, true) + " != " + __LOG.info(exp, true, true) + " +/- " + delta, msg, thisArg, ...params);
+const ASSERT_IN_DELTA = function(erg, exp, delta, msg, thisArg, ... params) {
+    return ASSERT(Math.abs(erg - exp) <= delta, __LOG.info(erg, true, true) + " != " + __LOG.info(exp, true, true) + " +/- " + delta, msg, thisArg, ... params);
 }
 
-const ASSERT_NOT_IN_DELTA = function(erg, exp, delta, msg, thisArg, ...params) {
-    return ASSERT(Math.abs(erg - exp) > delta, __LOG.info(erg, true, true) + " == " + __LOG.info(exp, true, true) + " +/- " + delta, msg, thisArg, ...params);
+const ASSERT_NOT_IN_DELTA = function(erg, exp, delta, msg, thisArg, ... params) {
+    return ASSERT(Math.abs(erg - exp) > delta, __LOG.info(erg, true, true) + " == " + __LOG.info(exp, true, true) + " +/- " + delta, msg, thisArg, ... params);
 }
 
-const ASSERT_IN_EPSILON = function(erg, exp, scale = 1, epsilon = __ASSERTEPSILON, msg, thisArg, ...params) {
+const ASSERT_IN_EPSILON = function(erg, exp, scale = 1, epsilon = __ASSERTEPSILON, msg, thisArg, ... params) {
     const __EPSILON = scale * epsilon;
     const __PROZENT = 100 * __EPSILON;
     const __DELTA = ((exp === 0.0) ? 1.0 : exp) * __EPSILON;
 
-    return ASSERT(Math.abs(erg - exp) <= __DELTA, __LOG.info(erg, true, true) + " != " + __LOG.info(exp, true, true) + " +/- " + __PROZENT + '%', msg, thisArg, ...params);
+    return ASSERT(Math.abs(erg - exp) <= __DELTA, __LOG.info(erg, true, true) + " != " + __LOG.info(exp, true, true) + " +/- " + __PROZENT + '%', msg, thisArg, ... params);
 }
 
-const ASSERT_NOT_IN_EPSILON = function(erg, exp, scale = 1, epsilon = __ASSERTEPSILON, msg, thisArg, ...params) {
+const ASSERT_NOT_IN_EPSILON = function(erg, exp, scale = 1, epsilon = __ASSERTEPSILON, msg, thisArg, ... params) {
     const __EPSILON = scale * epsilon;
     const __PROZENT = 100 * __EPSILON;
     const __DELTA = ((exp === 0.0) ? 1.0 : exp) * __EPSILON;
 
-    return ASSERT(Math.abs(erg - exp) > __DELTA, __LOG.info(erg, true, true) + " == " + __LOG.info(exp, true, true) + " +/- " + __PROZENT + '%', msg, thisArg, ...params);
+    return ASSERT(Math.abs(erg - exp) > __DELTA, __LOG.info(erg, true, true) + " == " + __LOG.info(exp, true, true) + " +/- " + __PROZENT + '%', msg, thisArg, ... params);
 }
 
-const ASSERT_OFTYPE = function(obj, type, msg, thisArg, ...params) {
-    return ASSERT((typeOf(obj) === type), __LOG.info(obj, true, true) + " ist kein " + __LOG.info(type, false), msg, thisArg, ...params);
+const ASSERT_OFTYPE = function(obj, type, msg, thisArg, ... params) {
+    return ASSERT((typeOf(obj) === type), __LOG.info(obj, true, true) + " ist kein " + __LOG.info(type, false), msg, thisArg, ... params);
 }
 
-const ASSERT_NOT_OFTYPE = function(obj, type, msg, thisArg, ...params) {
-    return ASSERT((typeOf(obj) !== type), __LOG.info(obj, true, true) + " ist " + __LOG.info(type, false), msg, thisArg, ...params);
+const ASSERT_NOT_OFTYPE = function(obj, type, msg, thisArg, ... params) {
+    return ASSERT((typeOf(obj) !== type), __LOG.info(obj, true, true) + " ist " + __LOG.info(type, false), msg, thisArg, ... params);
 }
 
-const ASSERT_TYPEOF = function(obj, type, msg, thisArg, ...params) {
-    return ASSERT(((typeof obj) === type), __LOG.info(obj, true, true) + " ist kein " + __LOG.info(type, false), msg, thisArg, ...params);
+const ASSERT_TYPEOF = function(obj, type, msg, thisArg, ... params) {
+    return ASSERT(((typeof obj) === type), __LOG.info(obj, true, true) + " ist kein " + __LOG.info(type, false), msg, thisArg, ... params);
 }
 
-const ASSERT_NOT_TYPEOF = function(obj, type, msg, thisArg, ...params) {
-    return ASSERT(((typeof obj) !== type), __LOG.info(obj, true, true) + " ist " + __LOG.info(type, false), msg, thisArg, ...params);
+const ASSERT_NOT_TYPEOF = function(obj, type, msg, thisArg, ... params) {
+    return ASSERT(((typeof obj) !== type), __LOG.info(obj, true, true) + " ist " + __LOG.info(type, false), msg, thisArg, ... params);
 }
 
-const ASSERT_INSTANCEOF = function(obj, cls, msg, thisArg, ...params) {
+const ASSERT_INSTANCEOF = function(obj, cls, msg, thisArg, ... params) {
     const __CLASSNAME = (cls || { }).name;
 
-    return ASSERT((obj instanceof cls), __LOG.info(obj, true, true) + " ist kein " + __LOG.info(__CLASSNAME, false), msg, thisArg, ...params);
+    return ASSERT((obj instanceof cls), __LOG.info(obj, true, true) + " ist kein " + __LOG.info(__CLASSNAME, false), msg, thisArg, ... params);
 }
 
-const ASSERT_NOT_INSTANCEOF = function(obj, cls, msg, thisArg, ...params) {
+const ASSERT_NOT_INSTANCEOF = function(obj, cls, msg, thisArg, ... params) {
     const __CLASSNAME = (cls || { }).name;
 
-    return ASSERT(! (obj instanceof cls), __LOG.info(obj, true, true) + " ist " + __LOG.info(__CLASSNAME, false), msg, thisArg, ...params);
+    return ASSERT(! (obj instanceof cls), __LOG.info(obj, true, true) + " ist " + __LOG.info(__CLASSNAME, false), msg, thisArg, ... params);
 }
 
-const ASSERT_MATCH = function(str, pattern, msg, thisArg, ...params) {
-    return ASSERT((str || "").match(pattern), __LOG.info(str, true, true) + " hat nicht das Muster " + String(pattern), msg, thisArg, ...params);
+const ASSERT_MATCH = function(str, pattern, msg, thisArg, ... params) {
+    return ASSERT((str || "").match(pattern), __LOG.info(str, true, true) + " hat nicht das Muster " + String(pattern), msg, thisArg, ... params);
 }
 
-const ASSERT_NOT_MATCH = function(str, pattern, msg, thisArg, ...params) {
-    return ASSERT(! (str || "").match(pattern), __LOG.info(str, true, true) + " hat das Muster " + String(pattern), msg, thisArg, ...params);
+const ASSERT_NOT_MATCH = function(str, pattern, msg, thisArg, ... params) {
+    return ASSERT(! (str || "").match(pattern), __LOG.info(str, true, true) + " hat das Muster " + String(pattern), msg, thisArg, ... params);
 }
 
 // ==================== Ende Abschnitt fuer sonstige ASSERT-Funktionen ====================
@@ -306,8 +306,8 @@ const ASSERT_NOT_MATCH = function(str, pattern, msg, thisArg, ...params) {
 // ==================== Abschnitt fuer globale Variablen ====================
 
 // Parameter fuer ASSERT_IN_DELTA, ASSERT_NOT_IN_DELTA, ASSERT_IN_EPSILON und ASSERT_NOT_IN_EPSILON (Float-Genauigkeit)...
-const __ASSERTDELTA = 0.000001;
-const __ASSERTEPSILON = Number.EPSILON;
+const __ASSERTDELTA     = 0.000001;
+const __ASSERTEPSILON   = Number.EPSILON;
 
 // ==================== Ende Abschnitt fuer globale Variablen ====================
 

--- a/misc/OS2/lib/test.lib.option.js
+++ b/misc/OS2/lib/test.lib.option.js
@@ -32,20 +32,30 @@ function UnitTestOption(name, desc, tests, load) {
 
 Class.define(UnitTestOption, UnitTest, {
             'prepare'     : async function(name, desc, thisArg, resultObj, resultFun, tableId) {
-                                UNUSED(resultObj, resultFun, tableId);
-
-                                const __TEAMPARAMS = new Team("Choromonets Odessa", "Ukraine", "1. Liga");
+                                UNUSED(thisArg, resultObj, resultFun, tableId);
 
                                 __LOG[1]("prepare()", name, desc);
 
-                                thisArg.optSet = await buildOptions(__TESTOPTCONFIG, __TESTOPTSET, {
-                                        'teamParams'  : __TEAMPARAMS,
-                                        'menuAnchor'  : getTable(1, 'div'),
-                                        'hideMenu'    : true,
-                                        'hideForm'    : {
-                                                           'team'   : true
-                                                        }
+                                const __TEAMPARAMS = new Team("Choromonets Odessa", "Ukraine", "1. Liga");
+
+                                const __MANAGER = new PageManager("Test-Umgebung", __TESTTEAMCLASS, () => {
+                                        return {
+                                                'teamParams'  : __TEAMPARAMS,
+                                                'menuAnchor'  : getTable(1, 'div'),
+                                                'hideMenu'    : true,
+                                                'hideForm'    : {
+                                                                    'team'  : true
+                                                                }
+                                            };
+                                    }, async optSet => {
+                                        UNUSED(optSet);
+
+                                        return true;
                                     });
+
+                                const __MAIN = new Main(__OPTCONFIG, null, __MANAGER);
+
+                                await __MAIN.run();
 
                                 return true;
                             },
@@ -194,9 +204,6 @@ const __TESTOPTCONFIG = {
 
 // ==================== Spezialisierter Abschnitt fuer Optionen ====================
 
-// Gesetzte Optionen (werden ggfs. von initOptions() angelegt und von loadOptions() gefuellt):
-const __TESTOPTSET = new Options(__TESTOPTCONFIG, '__TESTOPTSET');
-
 // Teamparameter fuer getrennte Speicherung der Optionen fuer Erst- und Zweitteam...
 const __TESTTEAMCLASS = new TeamClassification();
 
@@ -205,28 +212,6 @@ __TESTTEAMCLASS.optSelect = {
 //        'datenZat'   : true,
 //        'ligaSize'   : true
     };
-
-// Behandelt die Optionen und laedt das Benutzermenu
-// optConfig: Konfiguration der Optionen
-// optSet: Platz fuer die gesetzten Optionen
-// optParams: Eventuell notwendige Parameter zur Initialisierung
-// 'hideMenu': Optionen werden zwar geladen und genutzt, tauchen aber nicht im Benutzermenu auf
-// 'teamParams': Getrennte Daten-Option wird genutzt, hier: Team() mit 'LdNr'/'LgNr' des Erst- bzw. Zweitteams
-// 'menuAnchor': Startpunkt fuer das Optionsmenu auf der Seite
-// 'showForm': Checkliste der auf der Seite sichtbaren Optionen (true fuer sichtbar)
-// 'hideForm': Checkliste der auf der Seite unsichtbaren Optionen (true fuer unsichtbar)
-// 'formWidth': Anzahl der Elemente pro Zeile
-// 'formBreak': Elementnummer des ersten Zeilenumbruchs
-// return Promise auf gefuelltes Objekt mit den gesetzten Optionen
-function buildOptions(optConfig, optSet = undefined, optParams = { 'hideMenu' : false }) {
-    // Klassifikation ueber Land und Liga des Teams...
-    __TESTTEAMCLASS.optSet = optSet;  // Classification mit optSet verknuepfen
-    __TESTTEAMCLASS.teamParams = optParams.teamParams;  // Ermittelte Parameter
-
-    return startOptions(optConfig, optSet, __TESTTEAMCLASS).then(
-                optSet => showOptions(optSet, optParams),
-                defaultCatch);
-}
 
 // ==================== Ende Abschnitt fuer Optionen ====================
 

--- a/misc/OS2/lib/test.mock.gm.js
+++ b/misc/OS2/lib/test.mock.gm.js
@@ -83,7 +83,7 @@ Object.entries({
     }).forEach(([oldKey, newKey]) => {
         let old = this[oldKey];
         if (old && ((typeof GM[newKey]) === 'undefined')) {
-            GM[newKey] = function(...args) {
+            GM[newKey] = function(... args) {
                     return new Promise((resolve, reject) => {
                             try {
                                 resolve(old.apply(this, args));

--- a/misc/OS2/lib/util.class.js
+++ b/misc/OS2/lib/util.class.js
@@ -40,7 +40,7 @@ if ((typeof showAlert) === 'undefined') {
                 if (__BASEINIT) {
                     initFun = function() {
                                   // Basisklassen-Init aufrufen...
-                                  return __BASEINIT.call(this, arguments);
+                                  return __BASEINIT.apply(this, arguments);
                               };
                 } else {
                     initFun = function() {

--- a/misc/OS2/lib/util.log.js
+++ b/misc/OS2/lib/util.log.js
@@ -127,7 +127,7 @@ __LOG.init(window, 4, false);  // Zunaechst mal Loglevel 4, erneutes __LOG.init(
 // Makro fuer die Markierung bewusst ungenutzter Variablen und Parametern
 // params: Beliebig viele Parameter, mit denen nichts gemacht wird
 // return Liefert formal die Parameter zurueck
-function UNUSED(...unused) {
+function UNUSED(... unused) {
     return unused;
 }
 

--- a/misc/OS2/lib/util.option.page.js
+++ b/misc/OS2/lib/util.option.page.js
@@ -33,13 +33,13 @@ function groupData(data, byFun, filterFun, sortFun) {
     const __VALS = Object.values(data);
     const __BYKEYS = __VALS.map(__BYFUN);
     const __BYKEYSET = new Set(__BYKEYS);
-    const __BYKEYARRAY = [...__BYKEYSET];
+    const __BYKEYARRAY = [... __BYKEYSET];
     const __SORTEDKEYS = __BYKEYARRAY.sort(sortFun);
     const __GROUPEDKEYS = __SORTEDKEYS.map(byVal => __KEYS.filter((key, index) => {
                                                             UNUSED(key);
                                                             return __FILTERFUN(byVal, index, __BYKEYS);
                                                         }));
-    const __ASSIGN = ((keyArr, valArr) => Object.assign({ }, ...keyArr.map((key, index) => ({ [key] : valArr[index] }))));
+    const __ASSIGN = ((keyArr, valArr) => Object.assign({ }, ... keyArr.map((key, index) => ({ [key] : valArr[index] }))));
 
     return __ASSIGN(__SORTEDKEYS, __GROUPEDKEYS);
 }

--- a/misc/OS2/lib/util.option.run.js
+++ b/misc/OS2/lib/util.option.run.js
@@ -277,6 +277,10 @@ function optSelect(selList, ignList) {
 //}
 
 Class.define(ClassificationPair, Classification, {
+                    'assign'          : function(optSet, optParams) {
+                                            (this.A && this.A.assign(optSet, optParams));
+                                            (this.B && this.B.assign(optSet, optParams));
+                                        },
                     'renameOptions'  : function() {
                                            return (this.A ? this.A.renameOptions() : Promise.resolve()).then(() =>
                                                    (this.B ? this.B.renameOptions() : Promise.resolve()));

--- a/misc/OS2/lib/util.script.js
+++ b/misc/OS2/lib/util.script.js
@@ -38,8 +38,8 @@ function loadScript(url) {
 // fun: Auszufuehrende Funktion
 // params: Parameterliste fuer den Aufruf der Funktion
 // return Promise auf den Rueckgabewert dieser Funktion
-function getScript(url, fun, ...params) {
-    return loadScript(url).then(fun(...params),
+function getScript(url, fun, ... params) {
+    return loadScript(url).then(fun(... params),
                                 () => {
                                         __LOG[1]("Failed to load", url);
                                     });

--- a/misc/OS2/lib/util.store.js
+++ b/misc/OS2/lib/util.store.js
@@ -119,10 +119,10 @@ function GM_function(action, label, condition = true, altAction = undefined, lev
     const __LABEL = ((condition ? '+' : '-') + label);
     const __FUNKEY = (condition ? action : altAction);
 
-    return function(...args) {
+    return function(... args) {
             const __NAME = __LOG.info(args[0], false);
             __LOG[level](__LABEL, __NAME);
-            return GM[__FUNKEY](...args);
+            return GM[__FUNKEY](... args);
         };
 }
 

--- a/misc/OS2/test/index.html
+++ b/misc/OS2/test/index.html
@@ -61,6 +61,7 @@ const GM_info = {  // Mock GM_info data
         <script type="text/javascript" defer src="https://eselce.github.io/GitTest/misc/OS2/lib/util.option.page.node.js"></script>
         <script type="text/javascript" defer src="https://eselce.github.io/GitTest/misc/OS2/lib/util.option.page.js"></script>
         <script type="text/javascript" defer src="https://eselce.github.io/GitTest/misc/OS2/lib/util.option.run.js"></script>
+        <script type="text/javascript" defer src="https://eselce.github.io/GitTest/misc/OS2/lib/util.main.js"></script>
         <script type="text/javascript" defer src="https://eselce.github.io/GitTest/misc/OS2/lib/OS2.list.js"></script>
         <script type="text/javascript" defer src="https://eselce.github.io/GitTest/misc/OS2/lib/OS2.team.js"></script>
         <script type="text/javascript" defer src="https://eselce.github.io/GitTest/misc/OS2/lib/OS2.page.team.js"></script>

--- a/misc/mainchat.test.user.js
+++ b/misc/mainchat.test.user.js
@@ -41,6 +41,8 @@
 // _require      https://eselce.github.io/GitTest/misc/OS2/lib/util.option.page.node.js
 // _require      https://eselce.github.io/GitTest/misc/OS2/lib/util.option.page.js
 // _require      https://eselce.github.io/GitTest/misc/OS2/lib/util.option.run.js
+// _require      https://eselce.github.io/GitTest/misc/OS2/lib/util.main.js
+
 // _require      https://eselce.github.io/GitTest/misc/OS2/lib/OS2.list.js
 // _require      https://eselce.github.io/GitTest/misc/OS2/lib/OS2.team.js
 // _require      https://eselce.github.io/GitTest/misc/OS2/lib/OS2.page.js


### PR DESCRIPTION
util.main.js: __MAINCONFIG (mit setupManager, checkOptParams,
prepareOpt, verifyOpt) und Bereinigung des Main/PageManager-Frameworks
util.main.js: PageManager statt RundenLink, Zusatzparameter ...params
und zugehörige clone()-Funktion für die Generierung der Derivate
util.main.js: Als Require in 10/11+1 Benutzerskripten+Test aufgenommen
buildOptions(): Überall entfernt zugunsten des Main/PageManager-Frames
ClassificationPair: assign() an Unter-Classis weiterleiten
test.lib.option.js: prepare() umgestellt auf Main/PageManager
getPageIdFromURL(): Umstellung auf additive Version Leaf + Item
Bugfix Klasse Class: Aufruf mit apply() statt falsch mit call()
...: Abstands-Leerzeichen zur besseren Ansicht
TableManager: Object.call(this) ist unnötig

