### PR TITLE
Bugfix OS2.jugend und Bereinigung der Hauptprogramme

### DIFF
--- a/misc/OS2/OS2.ergebnisse.user.js
+++ b/misc/OS2/OS2.ergebnisse.user.js
@@ -146,28 +146,6 @@ const procErgebnisse = new PageManager("Ergebnisse", null, () => {
 
 // ==================== Ende Page-Manager fuer zu bearbeitende Seiten ====================
 
-// ==================== Spezialbehandlung der Startparameter ====================
-
-// Callback-Funktion fuer die Behandlung der Optionen und Laden des Benutzermenus
-// Diese Funktion erledigt nur Modifikationen und kann z.B. einfach optSet zurueckgeben!
-// optSet: Platz fuer die gesetzten Optionen
-// optParams: Eventuell notwendige Parameter zur Initialisierung
-// 'hideMenu': Optionen werden zwar geladen und genutzt, tauchen aber nicht im Benutzermenu auf
-// 'teamParams': Getrennte Daten-Option wird genutzt, hier: Team() mit 'LdNr'/'LgNr' des Erst- bzw. Zweitteams
-// 'menuAnchor': Startpunkt fuer das Optionsmenu auf der Seite
-// 'showForm': Checkliste der auf der Seite sichtbaren Optionen (true fuer sichtbar)
-// 'hideForm': Checkliste der auf der Seite unsichtbaren Optionen (true fuer unsichtbar)
-// 'formWidth': Anzahl der Elemente pro Zeile
-// 'formBreak': Elementnummer des ersten Zeilenumbruchs
-// return Gefuelltes Objekt mit den gesetzten Optionen
-function prepareOptions(optSet, optParams) {
-    UNUSED(optParams);
-
-    return optSet;
-}
-
-// ==================== Ende Spezialbehandlung der Startparameter ====================
-
 // ==================== Hauptprogramm ====================
 
 const __MAIN = new Main(__OPTCONFIG, null, procErgebnisse);

--- a/misc/OS2/OS2.fssturnier.user.js
+++ b/misc/OS2/OS2.fssturnier.user.js
@@ -3711,30 +3711,9 @@ const procOSFSSTurnier = new PageManager("FSS-Turniere", __TEAMCLASS, () => {
 
 // ==================== Ende Page-Manager fuer zu bearbeitende Seiten ====================
 
-// ==================== Spezialbehandlung der Startparameter ====================
-
-// Callback-Funktion fuer die Behandlung der Optionen und Laden des Benutzermenus
-// Diese Funktion erledigt nur Modifikationen und kann z.B. einfach optSet zurueckgeben!
-// optSet: Platz fuer die gesetzten Optionen
-// optParams: Eventuell notwendige Parameter zur Initialisierung
-// 'hideMenu': Optionen werden zwar geladen und genutzt, tauchen aber nicht im Benutzermenu auf
-// 'teamParams': Getrennte Daten-Option wird genutzt, hier: Team() mit 'LdNr'/'LgNr' des Erst- bzw. Zweitteams
-// 'menuAnchor': Startpunkt fuer das Optionsmenu auf der Seite
-// 'showForm': Checkliste der auf der Seite sichtbaren Optionen (true fuer sichtbar)
-// 'hideForm': Checkliste der auf der Seite unsichtbaren Optionen (true fuer unsichtbar)
-// 'formWidth': Anzahl der Elemente pro Zeile
-// 'formBreak': Elementnummer des ersten Zeilenumbruchs
-// return Gefuelltes Objekt mit den gesetzten Optionen
-function prepareOptions(optSet, optParams) {
-    UNUSED(optParams);
-
-    return optSet;
-}
-
-// ==================== Ende Spezialbehandlung der Startparameter ====================
-
 // ==================== Hauptprogramm ====================
 
+// Selektor fuer den richtigen PageManager...
 const __LEAFS = {
                     'haupt.php'      : 0,  // Ansicht "Haupt" (Managerbuero)
                     'fssturnier.php' : 1   // Ansicht "FSS-Turniere" (offizielles FSS-Turnier)

--- a/misc/OS2/OS2.haupt.user.js
+++ b/misc/OS2/OS2.haupt.user.js
@@ -238,28 +238,6 @@ const procHaupt = new PageManager("Haupt (Managerb\xFCro)", __TEAMCLASS, () => {
 
 // ==================== Ende Page-Manager fuer zu bearbeitende Seiten ====================
 
-// ==================== Spezialbehandlung der Startparameter ====================
-
-// Callback-Funktion fuer die Behandlung der Optionen und Laden des Benutzermenus
-// Diese Funktion erledigt nur Modifikationen und kann z.B. einfach optSet zurueckgeben!
-// optSet: Platz fuer die gesetzten Optionen
-// optParams: Eventuell notwendige Parameter zur Initialisierung
-// 'hideMenu': Optionen werden zwar geladen und genutzt, tauchen aber nicht im Benutzermenu auf
-// 'teamParams': Getrennte Daten-Option wird genutzt, hier: Team() mit 'LdNr'/'LgNr' des Erst- bzw. Zweitteams
-// 'menuAnchor': Startpunkt fuer das Optionsmenu auf der Seite
-// 'showForm': Checkliste der auf der Seite sichtbaren Optionen (true fuer sichtbar)
-// 'hideForm': Checkliste der auf der Seite unsichtbaren Optionen (true fuer unsichtbar)
-// 'formWidth': Anzahl der Elemente pro Zeile
-// 'formBreak': Elementnummer des ersten Zeilenumbruchs
-// return Gefuelltes Objekt mit den gesetzten Optionen
-function prepareOptions(optSet, optParams) {
-    UNUSED(optParams);
-
-    return optSet;
-}
-
-// ==================== Ende Spezialbehandlung der Startparameter ====================
-
 // ==================== Hauptprogramm ====================
 
 const __MAIN = new Main(__OPTCONFIG, null, procHaupt);

--- a/misc/OS2/OS2.jugend.user.js
+++ b/misc/OS2/OS2.jugend.user.js
@@ -1671,29 +1671,41 @@ function prepareOptions(optSet, optParams) {
     return optSet;
 }
 
+// Callback-Funktion fuer die Ermittlung des richtigen PageManagers
+// page: Die ueber den Selektor ermittelte Seitennummer
+// return Der zugehoerige PageManager (hier: 1-basiert)
+function setupManager(page) {
+    const __MAIN = this;
+
+    return __MAIN.pageManager[Math.max(0, page - 1)];
+}
+
 // ==================== Ende Spezialbehandlung der Startparameter ====================
 
 // ==================== Hauptprogramm ====================
 
+// Konfiguration der Callback-Funktionen zum Hauptprogramm...
 const __MAINCONFIG = {
-                        prepareOpt  : prepareOptions
+                        setupManager    : setupManager,
+                        prepareOpt      : prepareOptions
                     };
 
+// Selektor (Seite bzw. Parameter) fuer den richtigen PageManager...
 const __LEAFS = {
-                    'haupt.php' : 0,  // Ansicht "Haupt" (Managerbuero)
-                    'ju.php'    : 1   // Ansicht "Jugendteam" (page = 1, 2, 3, 4)
+                    'ju.php'    : 0,  // Ansicht "Jugendteam" (page = 1, 2, 3, 4)
+                    'haupt.php' : 5   // Ansicht "Haupt" (Managerbuero)
                 };
 const __ITEM = 'page';
 
-// URL-Legende:
-// page=0: Managerbuero
+// URL-Legende (1-basiert):
 // page=1: Jugend Teamuebersicht
 // page=2: Jugend Spielereinzelwerte
 // page=3: Jugend Opt. Skill
 // page=4: Jugend Optionen
+// page=5: Managerbuero
 const __MAIN = new Main(__OPTCONFIG, __MAINCONFIG,
-                        procHaupt, procTeamuebersicht, procSpielereinzelwerte,
-                        procOptSkill, procOptionen);
+                        procTeamuebersicht, procSpielereinzelwerte,
+                        procOptSkill, procOptionen, procHaupt);
 
 __MAIN.run(getPageIdFromURL, __LEAFS, __ITEM);
 

--- a/misc/OS2/OS2.scripts.user.js
+++ b/misc/OS2/OS2.scripts.user.js
@@ -312,28 +312,6 @@ const procScript = new PageManager("Script-Ansicht bei GitHub", null, () => {
 
 // ==================== Ende Page-Manager fuer zu bearbeitende Seiten ====================
 
-// ==================== Spezialbehandlung der Startparameter ====================
-
-// Callback-Funktion fuer die Behandlung der Optionen und Laden des Benutzermenus
-// Diese Funktion erledigt nur Modifikationen und kann z.B. einfach optSet zurueckgeben!
-// optSet: Platz fuer die gesetzten Optionen
-// optParams: Eventuell notwendige Parameter zur Initialisierung
-// 'hideMenu': Optionen werden zwar geladen und genutzt, tauchen aber nicht im Benutzermenu auf
-// 'teamParams': Getrennte Daten-Option wird genutzt, hier: Team() mit 'LdNr'/'LgNr' des Erst- bzw. Zweitteams
-// 'menuAnchor': Startpunkt fuer das Optionsmenu auf der Seite
-// 'showForm': Checkliste der auf der Seite sichtbaren Optionen (true fuer sichtbar)
-// 'hideForm': Checkliste der auf der Seite unsichtbaren Optionen (true fuer unsichtbar)
-// 'formWidth': Anzahl der Elemente pro Zeile
-// 'formBreak': Elementnummer des ersten Zeilenumbruchs
-// return Gefuelltes Objekt mit den gesetzten Optionen
-function prepareOptions(optSet, optParams) {
-    UNUSED(optParams);
-
-    return optSet;
-}
-
-// ==================== Ende Spezialbehandlung der Startparameter ====================
-
 // ==================== Hauptprogramm ====================
 
 const __MAIN = new Main(__OPTCONFIG, null, procScript);

--- a/misc/OS2/OS2.spielplan.user.js
+++ b/misc/OS2/OS2.spielplan.user.js
@@ -539,6 +539,10 @@ function prepareOptions(optSet, optParams) {
     return optSet;
 }
 
+
+// Callback-Funktion fuer die Ermittlung des richtigen PageManagers
+// page: Die ueber den Selektor ermittelte Seitennummer (hier: nur 6 gueltig)
+// return Der zugehoerige PageManager (hier: 0)
 function setupManager(page) {
     const __MAIN = this;
 
@@ -549,10 +553,13 @@ function setupManager(page) {
 
 // ==================== Hauptprogramm ====================
 
+// Konfiguration der Callback-Funktionen zum Hauptprogramm...
 const __MAINCONFIG = {
                         setupManager    : setupManager,
                         prepareOpt      : prepareOptions
                     };
+
+// Selektor (Seite bzw. Parameter) fuer den richtigen PageManager...
 const __LEAFS = {
                     'showteam.php' : 0, // Teamansicht Hauptfenster
                     'st.php'       : 0  // Teamansicht Popupfenster
@@ -566,7 +573,7 @@ const __ITEM = 's';
 // s=3: Statistik Saison
 // s=4: Statistik Gesamt
 // s=5: Teaminfo
-// s=6: Saisonplan (*) s=6 wird ersetzt durch Selection 0
+// s=6: Saisonplan (*) s=6 wird behandelt durch PageManager #0
 // s=7: Vereinshistorie
 // s=8: Transferhistorie
 // s=9: Leihhistorie

--- a/misc/OS2/OS2.tabelle.user.js
+++ b/misc/OS2/OS2.tabelle.user.js
@@ -1492,10 +1492,12 @@ function prepareOptions(optSet, optParams) {
 
 // ==================== Hauptprogramm ====================
 
+// Konfiguration der Callback-Funktionen zum Hauptprogramm...
 const __MAINCONFIG = {
                         prepareOpt  : prepareOptions
                     };
 
+// Selektor fuer den richtigen PageManager...
 const __LEAFS = {
                     'haupt.php' : 0,    // Ansicht "Haupt" (Managerbuero)
                     'lp.php'    : 1,    // Ansicht "Landespokale" (Pokalfinale)

--- a/misc/OS2/OS2.training.user.js
+++ b/misc/OS2/OS2.training.user.js
@@ -2856,12 +2856,13 @@ function checkOptParams(optParams, manager) {
 
 // ==================== Hauptprogramm ====================
 
-
+// Konfiguration der Callback-Funktionen zum Hauptprogramm...
 const __MAINCONFIG = {
                         checkOptParams  : checkOptParams,
                         prepareOpt      : prepareOptions
                     };
 
+// Selektor (Seite bzw. Parameter) fuer den richtigen PageManager...
 const __LEAFS = {
                     'zugabgabe.php' : 0,    // Ansicht "Zugabgabe" (p = 0, 1, 2)
                     'haupt.php'     : 3,    // Ansicht "Haupt" (Managerbuero)

--- a/misc/OS2/OS2.unittest.user.js
+++ b/misc/OS2/OS2.unittest.user.js
@@ -220,28 +220,6 @@ const procHaupt = new PageManager("Unit-Test Quellcode", null, () => {
 
 // ==================== Ende Page-Manager fuer zu bearbeitende Seiten ====================
 
-// ==================== Spezialbehandlung der Startparameter ====================
-
-// Callback-Funktion fuer die Behandlung der Optionen und Laden des Benutzermenus
-// Diese Funktion erledigt nur Modifikationen und kann z.B. einfach optSet zurueckgeben!
-// optSet: Platz fuer die gesetzten Optionen
-// optParams: Eventuell notwendige Parameter zur Initialisierung
-// 'hideMenu': Optionen werden zwar geladen und genutzt, tauchen aber nicht im Benutzermenu auf
-// 'teamParams': Getrennte Daten-Option wird genutzt, hier: Team() mit 'LdNr'/'LgNr' des Erst- bzw. Zweitteams
-// 'menuAnchor': Startpunkt fuer das Optionsmenu auf der Seite
-// 'showForm': Checkliste der auf der Seite sichtbaren Optionen (true fuer sichtbar)
-// 'hideForm': Checkliste der auf der Seite unsichtbaren Optionen (true fuer unsichtbar)
-// 'formWidth': Anzahl der Elemente pro Zeile
-// 'formBreak': Elementnummer des ersten Zeilenumbruchs
-// return Gefuelltes Objekt mit den gesetzten Optionen
-function prepareOptions(optSet, optParams) {
-    UNUSED(optParams);
-
-    return optSet;
-}
-
-// ==================== Ende Spezialbehandlung der Startparameter ====================
-
 // ==================== Hauptprogramm ====================
 
 const __MAIN = new Main(__OPTCONFIG, null, procHaupt);

--- a/misc/OS2/OS2.zugabgabe.user.js
+++ b/misc/OS2/OS2.zugabgabe.user.js
@@ -314,7 +314,7 @@ const procEinstellungen = new PageManager("Einstellungen", __TEAMCLASS, () => {
 function prepareOptions(optSet, optParams) {
     UNUSED(optParams);
 
-    // Werte aus der HTML-Seite ermitteln...
+    // TODO Werte aus der HTML-Seite ermitteln...
 
     // ... und abspeichern...
 
@@ -325,10 +325,12 @@ function prepareOptions(optSet, optParams) {
 
 // ==================== Hauptprogramm ====================
 
+// Konfiguration der Callback-Funktionen zum Hauptprogramm...
 const __MAINCONFIG = {
                         prepareOpt      : prepareOptions
                     };
 
+// Selektor (Seite bzw. Parameter) fuer den richtigen PageManager...
 const __LEAFS = {
                     'zugabgabe.php' :  0,   // Ansicht "Zugabgabe" (p = 0, 1, 2)
                     'haupt.php'     :  3,   // Ansicht "Haupt" (Managerbuero)


### PR DESCRIPTION
OS2.jugend: Es wurden falsche PageManager aufgerufen, Neusortierung
OS2.*: Hauptprogramme kommentiert und unnötige prepareOptions entfernt

