### PR TITLE
Bugfixes für nicht-Firefox-Browser (Chrome, Edge, Opera, ...)

### DIFF
--- a/misc/OS2/lib/lib.all.js
+++ b/misc/OS2/lib/lib.all.js
@@ -1349,10 +1349,10 @@ function defaultCatch(error, show) {
 // return Liefert Dateiname:Zeilennummer des Aufrufers als String
 function codeLineFor(ex, longForm = false, showFunName = false, ignoreCaller = false, ignoreLibs = true) {
     try {
-        const __EX = (ex || Error());
-        const __EXSTACK = getValue(__EX.stack, "");
+        const __EX = ((ex && ex.stack) ? ex : Error());
+        const __EXSTACK = __EX.stack;
         const __STACK = __EXSTACK.split("\n");
-        const __CHROMESTYLE = (~ __EXSTACK.indexOf('@'));  // "at" statt '@'-Stil (Chrome, Edge, Opera)
+        const __CHROMESTYLE = ! (~ __EXSTACK.indexOf('@'));  // "at" statt '@'-Stil (Chrome, Edge, Opera)
         const __START = (ex ? 0 : 1);  // Falls __EX hier produziert wurde, codeLineFor() selbst ignorieren!
         let countCaller = Number(ignoreCaller);  // Normalerweise 0 oder 1, bei 2 wird auch der naechste Aufrufer ignoriert!
         let ret;
@@ -1365,13 +1365,19 @@ function codeLineFor(ex, longForm = false, showFunName = false, ignoreCaller = f
 
             // Umformatierung auf Firefox-Stil...
             for (let i = 0; i < __STACK.length; i++) {
-                __STACK[i] = __STACK[i].replace(/^    at (\w+) \((\S+)\)$/, "$1@$2").replace(/^    at (\S+)$/, "@$1");
+                __STACK[i] = __STACK[i].replace(
+                                    /^    at async /, "    at async*").replace(
+                                    /^    at ([ \.\*\w]+) \((\S+)\)$/, "$1@$2").replace(
+                                    /^    at (\S+)$/, "@$1");
             }
         }
 
         for (let i = __START; i < __STACK.length; i++) {
             const __LINE = __STACK[i];
+
+            //__LOG[9]("STACK[" + i + "]:", __LINE.replace('@', " @ "));
             if (! __LINE) { break; }
+
             const [ __FUNNAME, __LOCATION ] = __LINE.split('@', 2);
             const __NAMELINE = getValue(__LOCATION, "").replace(/.*\//, ""); 
 
@@ -1434,7 +1440,7 @@ function checkCodeLineBlacklist(funName, fileName, strictFileName = false) {
         return true;
     }
 
-    const __FUNNAME = funName.replace(/^[ \w]+\*/, "").replace(/\/<$/, "");
+    const __FUNNAME = funName.replace(/^[ \w]+\*/, "").replace(/(\/<)+$/, "");
     const __FILENAME = __FILEMATCH[1];
     const __ENTRY = __CODELINEBLACKLIST[__FUNNAME];
     const __REGEXPKEYS = Object.keys(__CODELINEBLACKLISTREGEXP);
@@ -1945,8 +1951,10 @@ function XHRfactory(XHRname, XHRrequestClass, XHRopenFun) {
                             try {
                                 const __RESULT = (result.target || result);
                                 const __RET = __ONLOAD(__RESULT);
+                                const __OK = ((__RESULT.statusText === 'OK')
+                                            || (__RESULT.statusText === ""));
 
-                                if (__RESULT.statusText === 'OK') {
+                                if (__OK && (__RESULT.status === 200)) {
                                     resolve(__RET);
                                 } else {
                                     reject(__RESULT.statusText);
@@ -1960,7 +1968,9 @@ function XHRfactory(XHRname, XHRrequestClass, XHRopenFun) {
                     __D.error = (error => {
                             __LOG[1]("onerror():", error);
 
-                            reject(error);
+                            const __RET = __ONERROR(error);
+
+                            reject(__RET || error);
                         });
 
                     const __REQUEST = new __XMLREQUEST();

--- a/misc/OS2/lib/lib.test.all.js
+++ b/misc/OS2/lib/lib.test.all.js
@@ -235,9 +235,17 @@ function assertionCatch(error, ... attribs) {
 
     try {
         const __ISOBJ = ((typeof error) === 'object');  // Error-Objekt (true) oder skalarer Rueckgabewert (false)?
-        const __CODELINE = codeLine(true, false, true, false);
+        const __CODELINE = codeLineFor(error, true, false, true, false);
+
+        //__LOG[9]("CODELINE:", __CODELINE);
+
         const __MATCH = __CODELINE.match(/(.*?):(\d+(?::\d+)?)/);
-        const __LINECOLNUMBER = __MATCH[2];
+
+        if (! __CODELINE) {
+            __LOG[1]('assertionCatch():', "codeLine() is empty for error", error);
+        }
+
+        const __LINECOLNUMBER = (__CODELINE ? __MATCH[2] : null);
         const __LINENUM = (error.lineNumber || __LINECOLNUMBER);
         const __LABEL = `[${__LINENUM}] ${__DBMOD.Name}`;
         const __ERROR = (__ISOBJ ? Object.assign(error, ... attribs) : error);
@@ -1247,8 +1255,8 @@ __TESTTEAMCLASS.optSelect = {
 
 // ==================== Abschnitt fuer Test-Werkzeuge ====================
 
-    const __RESOLVED = Promise.resolve(true);
-    const __REJECTED = Promise.reject(false);  // NOTE "Uncaught (in promise) false"
+    const __RESOLVED = (() => Promise.resolve(true));
+    const __REJECTED = (() => Promise.reject(false));
     const __ERRORMSG = "Erroneous";
     const __ERRONEOUS = function() { throw Error(__ERRORMSG); };
     const __USEDCASE = sameValue;
@@ -1256,35 +1264,35 @@ __TESTTEAMCLASS.optSelect = {
     // Funktionalitaet der ASSERT-Funktionen...
     new UnitTest('test.assert.js Tools', "Test-Werkzeuge", {
             'callPromiseChainSimpleOK'        : function() {
-                                                    return callPromiseChain(__RESOLVED).then(value => {
+                                                    return callPromiseChain(__RESOLVED()).then(value => {
                                                             return ASSERT_TRUE(value, "Falsche R\xFCckgabe in Promise");
                                                         }, ex => {
                                                             return ASSERT(false, __LOG.info(ex), "Promise wurde rejected");
                                                         });
                                                 },
             'callPromiseChainSimpleFAIL'      : function() {
-                                                    return callPromiseChain(__REJECTED).then(value => {
+                                                    return callPromiseChain(__REJECTED()).then(value => {
                                                             return ASSERT(false, __LOG.info(value), "Promise wurde nicht rejected");
                                                         }, ex => {
                                                             return ASSERT_FALSE(ex, "Falsche R\xFCckgabe in Rejection");
                                                         });
                                                 },
             'callPromiseChainUsedCaseOK'      : function() {
-                                                    return callPromiseChain(__RESOLVED, __USEDCASE).then(value => {
+                                                    return callPromiseChain(__RESOLVED(), __USEDCASE).then(value => {
                                                             return ASSERT_TRUE(value, "Falsche R\xFCckgabe in Promise");
                                                         }, ex => {
                                                             return ASSERT(false, __LOG.info(ex), "Promise wurde rejected");
                                                         });
                                                 },
             'callPromiseChainUsedCaseFAIL'    : function() {
-                                                    return callPromiseChain(__REJECTED, __USEDCASE).then(value => {
+                                                    return callPromiseChain(__REJECTED(), __USEDCASE).then(value => {
                                                             return ASSERT(false, __LOG.info(value), "Promise wurde nicht rejected");
                                                         }, ex => {
                                                             return ASSERT_FALSE(ex, "Falsche R\xFCckgabe in Rejection");
                                                         });
                                                 },
             'callPromiseChainErroneousOK'     : function() {
-                                                    return callPromiseChain(__RESOLVED, __ERRONEOUS).then(value => {
+                                                    return callPromiseChain(__RESOLVED(), __ERRONEOUS).then(value => {
                                                             return ASSERT(false, __LOG.info(value), "Promise wurde nicht rejected");
                                                         }, async ex => {
                                                             ASSERT_INSTANCEOF(ex, Error, "Promise muss Error zur\xFCckgeben");
@@ -1298,28 +1306,28 @@ __TESTTEAMCLASS.optSelect = {
                                                         });
                                                 },
             'callPromiseChainErroneousFAIL'   : function() {
-                                                    return callPromiseChain(__REJECTED, __ERRONEOUS).then(value => {
+                                                    return callPromiseChain(__REJECTED(), __ERRONEOUS).then(value => {
                                                             return ASSERT(false, __LOG.info(value), "Promise wurde nicht rejected");
                                                         }, ex => {
                                                             return ASSERT_FALSE(ex, "Falsche R\xFCckgabe in Rejection");
                                                         });
                                                 },
             'callPromiseChainUsedUsedOK'      : function() {
-                                                    return callPromiseChain(__RESOLVED, __USEDCASE, __USEDCASE).then(value => {
+                                                    return callPromiseChain(__RESOLVED(), __USEDCASE, __USEDCASE).then(value => {
                                                             return ASSERT_TRUE(value, "Falsche R\xFCckgabe in Promise");
                                                         }, ex => {
                                                             return ASSERT(false, __LOG.info(ex), "Promise wurde rejected");
                                                         });
                                                 },
             'callPromiseChainUsedUsedFAIL'    : function() {
-                                                    return callPromiseChain(__REJECTED, __USEDCASE, __USEDCASE).then(value => {
+                                                    return callPromiseChain(__REJECTED(), __USEDCASE, __USEDCASE).then(value => {
                                                             return ASSERT(false, __LOG.info(value), "Promise wurde nicht rejected");
                                                         }, ex => {
                                                             return ASSERT_FALSE(ex, "Falsche R\xFCckgabe in Rejection");
                                                         });
                                                 },
             'callPromiseChainUsedFailOK'      : function() {
-                                                    return callPromiseChain(__RESOLVED, __USEDCASE, __ERRONEOUS).then(value => {
+                                                    return callPromiseChain(__RESOLVED(), __USEDCASE, __ERRONEOUS).then(value => {
                                                             return ASSERT(false, __LOG.info(value), "Promise wurde nicht rejected");
                                                         }, async ex => {
                                                             ASSERT_INSTANCEOF(ex, Error, "Promise muss Error zur\xFCckgeben");
@@ -1333,14 +1341,14 @@ __TESTTEAMCLASS.optSelect = {
                                                         });
                                                 },
             'callPromiseChainUsedFailFAIL'    : function() {
-                                                    return callPromiseChain(__REJECTED, __USEDCASE, __ERRONEOUS).then(value => {
+                                                    return callPromiseChain(__REJECTED(), __USEDCASE, __ERRONEOUS).then(value => {
                                                             return ASSERT(false, __LOG.info(value), "Promise wurde nicht rejected");
                                                         }, ex => {
                                                             return ASSERT_FALSE(ex, "Falsche R\xFCckgabe in Rejection");
                                                         });
                                                 },
             'callPromiseChainFailUsedOK'      : function() {
-                                                    return callPromiseChain(__RESOLVED, __ERRONEOUS, __USEDCASE).then(value => {
+                                                    return callPromiseChain(__RESOLVED(), __ERRONEOUS, __USEDCASE).then(value => {
                                                             return ASSERT(false, __LOG.info(value), "Promise wurde nicht rejected");
                                                         }, async ex => {
                                                             ASSERT_INSTANCEOF(ex, Error, "Promise muss Error zur\xFCckgeben");
@@ -1354,14 +1362,14 @@ __TESTTEAMCLASS.optSelect = {
                                                         });
                                                 },
             'callPromiseChainFailUsedFAIL'    : function() {
-                                                    return callPromiseChain(__REJECTED, __ERRONEOUS, __USEDCASE).then(value => {
+                                                    return callPromiseChain(__REJECTED(), __ERRONEOUS, __USEDCASE).then(value => {
                                                             return ASSERT(false, __LOG.info(value), "Promise wurde nicht rejected");
                                                         }, ex => {
                                                             return ASSERT_FALSE(ex, "Falsche R\xFCckgabe in Rejection");
                                                         });
                                                 },
             'callPromiseChainFailFailOK'      : function() {
-                                                    return callPromiseChain(__RESOLVED, __ERRONEOUS, __ERRONEOUS).then(value => {
+                                                    return callPromiseChain(__RESOLVED(), __ERRONEOUS, __ERRONEOUS).then(value => {
                                                             return ASSERT(false, __LOG.info(value), "Promise wurde nicht rejected");
                                                         }, async ex => {
                                                             ASSERT_INSTANCEOF(ex, Error, "Promise muss Error zur\xFCckgeben");
@@ -1375,7 +1383,7 @@ __TESTTEAMCLASS.optSelect = {
                                                         });
                                                 },
             'callPromiseChainFailFailFAIL'    : function() {
-                                                    return callPromiseChain(__REJECTED, __ERRONEOUS, __ERRONEOUS).then(value => {
+                                                    return callPromiseChain(__REJECTED(), __ERRONEOUS, __ERRONEOUS).then(value => {
                                                             return ASSERT(false, __LOG.info(value), "Promise wurde nicht rejected");
                                                         }, ex => {
                                                             return ASSERT_FALSE(ex, "Falsche R\xFCckgabe in Rejection");
@@ -5954,7 +5962,8 @@ __TESTTEAMCLASS.optSelect = {
                                     },
             'browseXMLCORS'       : function() {
                                         const [ __URL, __EXP ] = __TESTDATA['browseXMLCORS'];
-                                        const __ERRORMSG = "A network error occurred.";
+                                        const __ERRORMSG1 = "A network error occurred.";
+                                        const __ERRORMSG2 = "Failed to execute 'send' on 'XMLHttpRequest': Failed to load '" + __URL.replaceAll(' ', "%20") + "'.";
                                         const __ERRORTYPE = 'NetworkError';
                                         const __ERRORRESULT = 2152923155;
 
@@ -5964,15 +5973,20 @@ __TESTTEAMCLASS.optSelect = {
                                                 return ASSERT_NOT_EQUAL(__RET, __EXP, "browseXMLCORS() sollte keine XML-Daten liefern, sondern blockiert werden");
                                             }).catch(async ex => {
                                                 ASSERT_INSTANCEOF(ex, Error, "Promise muss Error zur\xFCckgeben");
-                                                ASSERT_EQUAL(ex.message, __ERRORMSG, "Fehlertext in Error falsch");
-                                                ASSERT_EQUAL(ex.name, __ERRORTYPE, "Fehlertyp in Error falsch");
+                                                if (ex.message === __ERRORMSG1) {
+                                                    ASSERT_EQUAL(ex.message, __ERRORMSG1, "Fehlertext in Error falsch");
+                                                    ASSERT_EQUAL(ex.result, __ERRORRESULT, "Result in Error falsch");
+                                                } else {
+                                                    ASSERT_EQUAL(ex.message, __ERRORMSG2, "Fehlertext in Error falsch");
+                                                }
 
-                                                return ASSERT_EQUAL(ex.result, __ERRORRESULT, "Result in Error falsch");
+                                                return ASSERT_EQUAL(ex.name, __ERRORTYPE, "Fehlertyp in Error falsch");
                                             });
                                     },
             'browseXMLCORSonload' : function() {
                                         const [ __URL, __EXP ] = __TESTDATA['browseXMLCORS'];
-                                        const __ERRORMSG = "A network error occurred.";
+                                        const __ERRORMSG1 = "A network error occurred.";
+                                        const __ERRORMSG2 = "Failed to execute 'send' on 'XMLHttpRequest': Failed to load '" + __URL.replaceAll(' ', "%20") + "'.";
                                         const __ERRORTYPE = 'NetworkError';
                                         const __ERRORRESULT = 2152923155;
 
@@ -5994,9 +6008,13 @@ __TESTTEAMCLASS.optSelect = {
                                                     }).catch(ex => {
                                                             try {
                                                                 ASSERT_INSTANCEOF(ex, Error, "Promise muss Error zur\xFCckgeben");
-                                                                ASSERT_EQUAL(ex.message, __ERRORMSG, "Fehlertext in Error falsch");
+                                                                if (ex.message === __ERRORMSG1) {
+                                                                    ASSERT_EQUAL(ex.message, __ERRORMSG1, "Fehlertext in Error falsch");
+                                                                    ASSERT_EQUAL(ex.result, __ERRORRESULT, "Result in Error falsch");
+                                                                } else {
+                                                                    ASSERT_EQUAL(ex.message, __ERRORMSG2, "Fehlertext in Error falsch");
+                                                                }
                                                                 ASSERT_EQUAL(ex.name, __ERRORTYPE, "Fehlertyp in Error falsch");
-                                                                ASSERT_EQUAL(ex.result, __ERRORRESULT, "Result in Error falsch");
 
                                                                 return resolve(true);
                                                             } catch (ex) {

--- a/misc/OS2/lib/lib.test.base.js
+++ b/misc/OS2/lib/lib.test.base.js
@@ -228,9 +228,17 @@ function assertionCatch(error, ... attribs) {
 
     try {
         const __ISOBJ = ((typeof error) === 'object');  // Error-Objekt (true) oder skalarer Rueckgabewert (false)?
-        const __CODELINE = codeLine(true, false, true, false);
+        const __CODELINE = codeLineFor(error, true, false, true, false);
+
+        //__LOG[9]("CODELINE:", __CODELINE);
+
         const __MATCH = __CODELINE.match(/(.*?):(\d+(?::\d+)?)/);
-        const __LINECOLNUMBER = __MATCH[2];
+
+        if (! __CODELINE) {
+            __LOG[1]('assertionCatch():', "codeLine() is empty for error", error);
+        }
+
+        const __LINECOLNUMBER = (__CODELINE ? __MATCH[2] : null);
         const __LINENUM = (error.lineNumber || __LINECOLNUMBER);
         const __LABEL = `[${__LINENUM}] ${__DBMOD.Name}`;
         const __ERROR = (__ISOBJ ? Object.assign(error, ... attribs) : error);

--- a/misc/OS2/lib/lib.test.js
+++ b/misc/OS2/lib/lib.test.js
@@ -35,8 +35,8 @@
 
 // ==================== Abschnitt fuer Test-Werkzeuge ====================
 
-    const __RESOLVED = Promise.resolve(true);
-    const __REJECTED = Promise.reject(false);  // NOTE "Uncaught (in promise) false"
+    const __RESOLVED = (() => Promise.resolve(true));
+    const __REJECTED = (() => Promise.reject(false));
     const __ERRORMSG = "Erroneous";
     const __ERRONEOUS = function() { throw Error(__ERRORMSG); };
     const __USEDCASE = sameValue;
@@ -44,35 +44,35 @@
     // Funktionalitaet der ASSERT-Funktionen...
     new UnitTest('test.assert.js Tools', "Test-Werkzeuge", {
             'callPromiseChainSimpleOK'        : function() {
-                                                    return callPromiseChain(__RESOLVED).then(value => {
+                                                    return callPromiseChain(__RESOLVED()).then(value => {
                                                             return ASSERT_TRUE(value, "Falsche R\xFCckgabe in Promise");
                                                         }, ex => {
                                                             return ASSERT(false, __LOG.info(ex), "Promise wurde rejected");
                                                         });
                                                 },
             'callPromiseChainSimpleFAIL'      : function() {
-                                                    return callPromiseChain(__REJECTED).then(value => {
+                                                    return callPromiseChain(__REJECTED()).then(value => {
                                                             return ASSERT(false, __LOG.info(value), "Promise wurde nicht rejected");
                                                         }, ex => {
                                                             return ASSERT_FALSE(ex, "Falsche R\xFCckgabe in Rejection");
                                                         });
                                                 },
             'callPromiseChainUsedCaseOK'      : function() {
-                                                    return callPromiseChain(__RESOLVED, __USEDCASE).then(value => {
+                                                    return callPromiseChain(__RESOLVED(), __USEDCASE).then(value => {
                                                             return ASSERT_TRUE(value, "Falsche R\xFCckgabe in Promise");
                                                         }, ex => {
                                                             return ASSERT(false, __LOG.info(ex), "Promise wurde rejected");
                                                         });
                                                 },
             'callPromiseChainUsedCaseFAIL'    : function() {
-                                                    return callPromiseChain(__REJECTED, __USEDCASE).then(value => {
+                                                    return callPromiseChain(__REJECTED(), __USEDCASE).then(value => {
                                                             return ASSERT(false, __LOG.info(value), "Promise wurde nicht rejected");
                                                         }, ex => {
                                                             return ASSERT_FALSE(ex, "Falsche R\xFCckgabe in Rejection");
                                                         });
                                                 },
             'callPromiseChainErroneousOK'     : function() {
-                                                    return callPromiseChain(__RESOLVED, __ERRONEOUS).then(value => {
+                                                    return callPromiseChain(__RESOLVED(), __ERRONEOUS).then(value => {
                                                             return ASSERT(false, __LOG.info(value), "Promise wurde nicht rejected");
                                                         }, async ex => {
                                                             ASSERT_INSTANCEOF(ex, Error, "Promise muss Error zur\xFCckgeben");
@@ -86,28 +86,28 @@
                                                         });
                                                 },
             'callPromiseChainErroneousFAIL'   : function() {
-                                                    return callPromiseChain(__REJECTED, __ERRONEOUS).then(value => {
+                                                    return callPromiseChain(__REJECTED(), __ERRONEOUS).then(value => {
                                                             return ASSERT(false, __LOG.info(value), "Promise wurde nicht rejected");
                                                         }, ex => {
                                                             return ASSERT_FALSE(ex, "Falsche R\xFCckgabe in Rejection");
                                                         });
                                                 },
             'callPromiseChainUsedUsedOK'      : function() {
-                                                    return callPromiseChain(__RESOLVED, __USEDCASE, __USEDCASE).then(value => {
+                                                    return callPromiseChain(__RESOLVED(), __USEDCASE, __USEDCASE).then(value => {
                                                             return ASSERT_TRUE(value, "Falsche R\xFCckgabe in Promise");
                                                         }, ex => {
                                                             return ASSERT(false, __LOG.info(ex), "Promise wurde rejected");
                                                         });
                                                 },
             'callPromiseChainUsedUsedFAIL'    : function() {
-                                                    return callPromiseChain(__REJECTED, __USEDCASE, __USEDCASE).then(value => {
+                                                    return callPromiseChain(__REJECTED(), __USEDCASE, __USEDCASE).then(value => {
                                                             return ASSERT(false, __LOG.info(value), "Promise wurde nicht rejected");
                                                         }, ex => {
                                                             return ASSERT_FALSE(ex, "Falsche R\xFCckgabe in Rejection");
                                                         });
                                                 },
             'callPromiseChainUsedFailOK'      : function() {
-                                                    return callPromiseChain(__RESOLVED, __USEDCASE, __ERRONEOUS).then(value => {
+                                                    return callPromiseChain(__RESOLVED(), __USEDCASE, __ERRONEOUS).then(value => {
                                                             return ASSERT(false, __LOG.info(value), "Promise wurde nicht rejected");
                                                         }, async ex => {
                                                             ASSERT_INSTANCEOF(ex, Error, "Promise muss Error zur\xFCckgeben");
@@ -121,14 +121,14 @@
                                                         });
                                                 },
             'callPromiseChainUsedFailFAIL'    : function() {
-                                                    return callPromiseChain(__REJECTED, __USEDCASE, __ERRONEOUS).then(value => {
+                                                    return callPromiseChain(__REJECTED(), __USEDCASE, __ERRONEOUS).then(value => {
                                                             return ASSERT(false, __LOG.info(value), "Promise wurde nicht rejected");
                                                         }, ex => {
                                                             return ASSERT_FALSE(ex, "Falsche R\xFCckgabe in Rejection");
                                                         });
                                                 },
             'callPromiseChainFailUsedOK'      : function() {
-                                                    return callPromiseChain(__RESOLVED, __ERRONEOUS, __USEDCASE).then(value => {
+                                                    return callPromiseChain(__RESOLVED(), __ERRONEOUS, __USEDCASE).then(value => {
                                                             return ASSERT(false, __LOG.info(value), "Promise wurde nicht rejected");
                                                         }, async ex => {
                                                             ASSERT_INSTANCEOF(ex, Error, "Promise muss Error zur\xFCckgeben");
@@ -142,14 +142,14 @@
                                                         });
                                                 },
             'callPromiseChainFailUsedFAIL'    : function() {
-                                                    return callPromiseChain(__REJECTED, __ERRONEOUS, __USEDCASE).then(value => {
+                                                    return callPromiseChain(__REJECTED(), __ERRONEOUS, __USEDCASE).then(value => {
                                                             return ASSERT(false, __LOG.info(value), "Promise wurde nicht rejected");
                                                         }, ex => {
                                                             return ASSERT_FALSE(ex, "Falsche R\xFCckgabe in Rejection");
                                                         });
                                                 },
             'callPromiseChainFailFailOK'      : function() {
-                                                    return callPromiseChain(__RESOLVED, __ERRONEOUS, __ERRONEOUS).then(value => {
+                                                    return callPromiseChain(__RESOLVED(), __ERRONEOUS, __ERRONEOUS).then(value => {
                                                             return ASSERT(false, __LOG.info(value), "Promise wurde nicht rejected");
                                                         }, async ex => {
                                                             ASSERT_INSTANCEOF(ex, Error, "Promise muss Error zur\xFCckgeben");
@@ -163,7 +163,7 @@
                                                         });
                                                 },
             'callPromiseChainFailFailFAIL'    : function() {
-                                                    return callPromiseChain(__REJECTED, __ERRONEOUS, __ERRONEOUS).then(value => {
+                                                    return callPromiseChain(__REJECTED(), __ERRONEOUS, __ERRONEOUS).then(value => {
                                                             return ASSERT(false, __LOG.info(value), "Promise wurde nicht rejected");
                                                         }, ex => {
                                                             return ASSERT_FALSE(ex, "Falsche R\xFCckgabe in Rejection");
@@ -4742,7 +4742,8 @@
                                     },
             'browseXMLCORS'       : function() {
                                         const [ __URL, __EXP ] = __TESTDATA['browseXMLCORS'];
-                                        const __ERRORMSG = "A network error occurred.";
+                                        const __ERRORMSG1 = "A network error occurred.";
+                                        const __ERRORMSG2 = "Failed to execute 'send' on 'XMLHttpRequest': Failed to load '" + __URL.replaceAll(' ', "%20") + "'.";
                                         const __ERRORTYPE = 'NetworkError';
                                         const __ERRORRESULT = 2152923155;
 
@@ -4752,15 +4753,20 @@
                                                 return ASSERT_NOT_EQUAL(__RET, __EXP, "browseXMLCORS() sollte keine XML-Daten liefern, sondern blockiert werden");
                                             }).catch(async ex => {
                                                 ASSERT_INSTANCEOF(ex, Error, "Promise muss Error zur\xFCckgeben");
-                                                ASSERT_EQUAL(ex.message, __ERRORMSG, "Fehlertext in Error falsch");
-                                                ASSERT_EQUAL(ex.name, __ERRORTYPE, "Fehlertyp in Error falsch");
+                                                if (ex.message === __ERRORMSG1) {
+                                                    ASSERT_EQUAL(ex.message, __ERRORMSG1, "Fehlertext in Error falsch");
+                                                    ASSERT_EQUAL(ex.result, __ERRORRESULT, "Result in Error falsch");
+                                                } else {
+                                                    ASSERT_EQUAL(ex.message, __ERRORMSG2, "Fehlertext in Error falsch");
+                                                }
 
-                                                return ASSERT_EQUAL(ex.result, __ERRORRESULT, "Result in Error falsch");
+                                                return ASSERT_EQUAL(ex.name, __ERRORTYPE, "Fehlertyp in Error falsch");
                                             });
                                     },
             'browseXMLCORSonload' : function() {
                                         const [ __URL, __EXP ] = __TESTDATA['browseXMLCORS'];
-                                        const __ERRORMSG = "A network error occurred.";
+                                        const __ERRORMSG1 = "A network error occurred.";
+                                        const __ERRORMSG2 = "Failed to execute 'send' on 'XMLHttpRequest': Failed to load '" + __URL.replaceAll(' ', "%20") + "'.";
                                         const __ERRORTYPE = 'NetworkError';
                                         const __ERRORRESULT = 2152923155;
 
@@ -4782,9 +4788,13 @@
                                                     }).catch(ex => {
                                                             try {
                                                                 ASSERT_INSTANCEOF(ex, Error, "Promise muss Error zur\xFCckgeben");
-                                                                ASSERT_EQUAL(ex.message, __ERRORMSG, "Fehlertext in Error falsch");
+                                                                if (ex.message === __ERRORMSG1) {
+                                                                    ASSERT_EQUAL(ex.message, __ERRORMSG1, "Fehlertext in Error falsch");
+                                                                    ASSERT_EQUAL(ex.result, __ERRORRESULT, "Result in Error falsch");
+                                                                } else {
+                                                                    ASSERT_EQUAL(ex.message, __ERRORMSG2, "Fehlertext in Error falsch");
+                                                                }
                                                                 ASSERT_EQUAL(ex.name, __ERRORTYPE, "Fehlertyp in Error falsch");
-                                                                ASSERT_EQUAL(ex.result, __ERRORRESULT, "Result in Error falsch");
 
                                                                 return resolve(true);
                                                             } catch (ex) {

--- a/misc/OS2/lib/test.assert.js
+++ b/misc/OS2/lib/test.assert.js
@@ -218,9 +218,17 @@ function assertionCatch(error, ... attribs) {
 
     try {
         const __ISOBJ = ((typeof error) === 'object');  // Error-Objekt (true) oder skalarer Rueckgabewert (false)?
-        const __CODELINE = codeLine(true, false, true, false);
+        const __CODELINE = codeLineFor(error, true, false, true, false);
+
+        //__LOG[9]("CODELINE:", __CODELINE);
+
         const __MATCH = __CODELINE.match(/(.*?):(\d+(?::\d+)?)/);
-        const __LINECOLNUMBER = __MATCH[2];
+
+        if (! __CODELINE) {
+            __LOG[1]('assertionCatch():', "codeLine() is empty for error", error);
+        }
+
+        const __LINECOLNUMBER = (__CODELINE ? __MATCH[2] : null);
         const __LINENUM = (error.lineNumber || __LINECOLNUMBER);
         const __LABEL = `[${__LINENUM}] ${__DBMOD.Name}`;
         const __ERROR = (__ISOBJ ? Object.assign(error, ... attribs) : error);

--- a/misc/OS2/lib/util.xhr.js
+++ b/misc/OS2/lib/util.xhr.js
@@ -152,8 +152,10 @@ function XHRfactory(XHRname, XHRrequestClass, XHRopenFun) {
                             try {
                                 const __RESULT = (result.target || result);
                                 const __RET = __ONLOAD(__RESULT);
+                                const __OK = ((__RESULT.statusText === 'OK')
+                                            || (__RESULT.statusText === ""));
 
-                                if (__RESULT.statusText === 'OK') {
+                                if (__OK && (__RESULT.status === 200)) {
                                     resolve(__RET);
                                 } else {
                                     reject(__RESULT.statusText);
@@ -167,7 +169,9 @@ function XHRfactory(XHRname, XHRrequestClass, XHRopenFun) {
                     __D.error = (error => {
                             __LOG[1]("onerror():", error);
 
-                            reject(error);
+                            const __RET = __ONERROR(error);
+
+                            reject(__RET || error);
                         });
 
                     const __REQUEST = new __XMLREQUEST();

--- a/misc/OS2/test/test.assert.test.js
+++ b/misc/OS2/test/test.assert.test.js
@@ -22,8 +22,8 @@
 
 // ==================== Abschnitt fuer Test-Werkzeuge ====================
 
-    const __RESOLVED = Promise.resolve(true);
-    const __REJECTED = Promise.reject(false);  // NOTE "Uncaught (in promise) false"
+    const __RESOLVED = (() => Promise.resolve(true));
+    const __REJECTED = (() => Promise.reject(false));
     const __ERRORMSG = "Erroneous";
     const __ERRONEOUS = function() { throw Error(__ERRORMSG); };
     const __USEDCASE = sameValue;
@@ -31,35 +31,35 @@
     // Funktionalitaet der ASSERT-Funktionen...
     new UnitTest('test.assert.js Tools', "Test-Werkzeuge", {
             'callPromiseChainSimpleOK'        : function() {
-                                                    return callPromiseChain(__RESOLVED).then(value => {
+                                                    return callPromiseChain(__RESOLVED()).then(value => {
                                                             return ASSERT_TRUE(value, "Falsche R\xFCckgabe in Promise");
                                                         }, ex => {
                                                             return ASSERT(false, __LOG.info(ex), "Promise wurde rejected");
                                                         });
                                                 },
             'callPromiseChainSimpleFAIL'      : function() {
-                                                    return callPromiseChain(__REJECTED).then(value => {
+                                                    return callPromiseChain(__REJECTED()).then(value => {
                                                             return ASSERT(false, __LOG.info(value), "Promise wurde nicht rejected");
                                                         }, ex => {
                                                             return ASSERT_FALSE(ex, "Falsche R\xFCckgabe in Rejection");
                                                         });
                                                 },
             'callPromiseChainUsedCaseOK'      : function() {
-                                                    return callPromiseChain(__RESOLVED, __USEDCASE).then(value => {
+                                                    return callPromiseChain(__RESOLVED(), __USEDCASE).then(value => {
                                                             return ASSERT_TRUE(value, "Falsche R\xFCckgabe in Promise");
                                                         }, ex => {
                                                             return ASSERT(false, __LOG.info(ex), "Promise wurde rejected");
                                                         });
                                                 },
             'callPromiseChainUsedCaseFAIL'    : function() {
-                                                    return callPromiseChain(__REJECTED, __USEDCASE).then(value => {
+                                                    return callPromiseChain(__REJECTED(), __USEDCASE).then(value => {
                                                             return ASSERT(false, __LOG.info(value), "Promise wurde nicht rejected");
                                                         }, ex => {
                                                             return ASSERT_FALSE(ex, "Falsche R\xFCckgabe in Rejection");
                                                         });
                                                 },
             'callPromiseChainErroneousOK'     : function() {
-                                                    return callPromiseChain(__RESOLVED, __ERRONEOUS).then(value => {
+                                                    return callPromiseChain(__RESOLVED(), __ERRONEOUS).then(value => {
                                                             return ASSERT(false, __LOG.info(value), "Promise wurde nicht rejected");
                                                         }, async ex => {
                                                             ASSERT_INSTANCEOF(ex, Error, "Promise muss Error zur\xFCckgeben");
@@ -73,28 +73,28 @@
                                                         });
                                                 },
             'callPromiseChainErroneousFAIL'   : function() {
-                                                    return callPromiseChain(__REJECTED, __ERRONEOUS).then(value => {
+                                                    return callPromiseChain(__REJECTED(), __ERRONEOUS).then(value => {
                                                             return ASSERT(false, __LOG.info(value), "Promise wurde nicht rejected");
                                                         }, ex => {
                                                             return ASSERT_FALSE(ex, "Falsche R\xFCckgabe in Rejection");
                                                         });
                                                 },
             'callPromiseChainUsedUsedOK'      : function() {
-                                                    return callPromiseChain(__RESOLVED, __USEDCASE, __USEDCASE).then(value => {
+                                                    return callPromiseChain(__RESOLVED(), __USEDCASE, __USEDCASE).then(value => {
                                                             return ASSERT_TRUE(value, "Falsche R\xFCckgabe in Promise");
                                                         }, ex => {
                                                             return ASSERT(false, __LOG.info(ex), "Promise wurde rejected");
                                                         });
                                                 },
             'callPromiseChainUsedUsedFAIL'    : function() {
-                                                    return callPromiseChain(__REJECTED, __USEDCASE, __USEDCASE).then(value => {
+                                                    return callPromiseChain(__REJECTED(), __USEDCASE, __USEDCASE).then(value => {
                                                             return ASSERT(false, __LOG.info(value), "Promise wurde nicht rejected");
                                                         }, ex => {
                                                             return ASSERT_FALSE(ex, "Falsche R\xFCckgabe in Rejection");
                                                         });
                                                 },
             'callPromiseChainUsedFailOK'      : function() {
-                                                    return callPromiseChain(__RESOLVED, __USEDCASE, __ERRONEOUS).then(value => {
+                                                    return callPromiseChain(__RESOLVED(), __USEDCASE, __ERRONEOUS).then(value => {
                                                             return ASSERT(false, __LOG.info(value), "Promise wurde nicht rejected");
                                                         }, async ex => {
                                                             ASSERT_INSTANCEOF(ex, Error, "Promise muss Error zur\xFCckgeben");
@@ -108,14 +108,14 @@
                                                         });
                                                 },
             'callPromiseChainUsedFailFAIL'    : function() {
-                                                    return callPromiseChain(__REJECTED, __USEDCASE, __ERRONEOUS).then(value => {
+                                                    return callPromiseChain(__REJECTED(), __USEDCASE, __ERRONEOUS).then(value => {
                                                             return ASSERT(false, __LOG.info(value), "Promise wurde nicht rejected");
                                                         }, ex => {
                                                             return ASSERT_FALSE(ex, "Falsche R\xFCckgabe in Rejection");
                                                         });
                                                 },
             'callPromiseChainFailUsedOK'      : function() {
-                                                    return callPromiseChain(__RESOLVED, __ERRONEOUS, __USEDCASE).then(value => {
+                                                    return callPromiseChain(__RESOLVED(), __ERRONEOUS, __USEDCASE).then(value => {
                                                             return ASSERT(false, __LOG.info(value), "Promise wurde nicht rejected");
                                                         }, async ex => {
                                                             ASSERT_INSTANCEOF(ex, Error, "Promise muss Error zur\xFCckgeben");
@@ -129,14 +129,14 @@
                                                         });
                                                 },
             'callPromiseChainFailUsedFAIL'    : function() {
-                                                    return callPromiseChain(__REJECTED, __ERRONEOUS, __USEDCASE).then(value => {
+                                                    return callPromiseChain(__REJECTED(), __ERRONEOUS, __USEDCASE).then(value => {
                                                             return ASSERT(false, __LOG.info(value), "Promise wurde nicht rejected");
                                                         }, ex => {
                                                             return ASSERT_FALSE(ex, "Falsche R\xFCckgabe in Rejection");
                                                         });
                                                 },
             'callPromiseChainFailFailOK'      : function() {
-                                                    return callPromiseChain(__RESOLVED, __ERRONEOUS, __ERRONEOUS).then(value => {
+                                                    return callPromiseChain(__RESOLVED(), __ERRONEOUS, __ERRONEOUS).then(value => {
                                                             return ASSERT(false, __LOG.info(value), "Promise wurde nicht rejected");
                                                         }, async ex => {
                                                             ASSERT_INSTANCEOF(ex, Error, "Promise muss Error zur\xFCckgeben");
@@ -150,7 +150,7 @@
                                                         });
                                                 },
             'callPromiseChainFailFailFAIL'    : function() {
-                                                    return callPromiseChain(__REJECTED, __ERRONEOUS, __ERRONEOUS).then(value => {
+                                                    return callPromiseChain(__REJECTED(), __ERRONEOUS, __ERRONEOUS).then(value => {
                                                             return ASSERT(false, __LOG.info(value), "Promise wurde nicht rejected");
                                                         }, ex => {
                                                             return ASSERT_FALSE(ex, "Falsche R\xFCckgabe in Rejection");

--- a/misc/OS2/test/util.xhr.test.js
+++ b/misc/OS2/test/util.xhr.test.js
@@ -87,7 +87,8 @@
                                     },
             'browseXMLCORS'       : function() {
                                         const [ __URL, __EXP ] = __TESTDATA['browseXMLCORS'];
-                                        const __ERRORMSG = "A network error occurred.";
+                                        const __ERRORMSG1 = "A network error occurred.";
+                                        const __ERRORMSG2 = "Failed to execute 'send' on 'XMLHttpRequest': Failed to load '" + __URL.replaceAll(' ', "%20") + "'.";
                                         const __ERRORTYPE = 'NetworkError';
                                         const __ERRORRESULT = 2152923155;
 
@@ -97,15 +98,20 @@
                                                 return ASSERT_NOT_EQUAL(__RET, __EXP, "browseXMLCORS() sollte keine XML-Daten liefern, sondern blockiert werden");
                                             }).catch(async ex => {
                                                 ASSERT_INSTANCEOF(ex, Error, "Promise muss Error zur\xFCckgeben");
-                                                ASSERT_EQUAL(ex.message, __ERRORMSG, "Fehlertext in Error falsch");
-                                                ASSERT_EQUAL(ex.name, __ERRORTYPE, "Fehlertyp in Error falsch");
+                                                if (ex.message === __ERRORMSG1) {
+                                                    ASSERT_EQUAL(ex.message, __ERRORMSG1, "Fehlertext in Error falsch");
+                                                    ASSERT_EQUAL(ex.result, __ERRORRESULT, "Result in Error falsch");
+                                                } else {
+                                                    ASSERT_EQUAL(ex.message, __ERRORMSG2, "Fehlertext in Error falsch");
+                                                }
 
-                                                return ASSERT_EQUAL(ex.result, __ERRORRESULT, "Result in Error falsch");
+                                                return ASSERT_EQUAL(ex.name, __ERRORTYPE, "Fehlertyp in Error falsch");
                                             });
                                     },
             'browseXMLCORSonload' : function() {
                                         const [ __URL, __EXP ] = __TESTDATA['browseXMLCORS'];
-                                        const __ERRORMSG = "A network error occurred.";
+                                        const __ERRORMSG1 = "A network error occurred.";
+                                        const __ERRORMSG2 = "Failed to execute 'send' on 'XMLHttpRequest': Failed to load '" + __URL.replaceAll(' ', "%20") + "'.";
                                         const __ERRORTYPE = 'NetworkError';
                                         const __ERRORRESULT = 2152923155;
 
@@ -127,9 +133,13 @@
                                                     }).catch(ex => {
                                                             try {
                                                                 ASSERT_INSTANCEOF(ex, Error, "Promise muss Error zur\xFCckgeben");
-                                                                ASSERT_EQUAL(ex.message, __ERRORMSG, "Fehlertext in Error falsch");
+                                                                if (ex.message === __ERRORMSG1) {
+                                                                    ASSERT_EQUAL(ex.message, __ERRORMSG1, "Fehlertext in Error falsch");
+                                                                    ASSERT_EQUAL(ex.result, __ERRORRESULT, "Result in Error falsch");
+                                                                } else {
+                                                                    ASSERT_EQUAL(ex.message, __ERRORMSG2, "Fehlertext in Error falsch");
+                                                                }
                                                                 ASSERT_EQUAL(ex.name, __ERRORTYPE, "Fehlertyp in Error falsch");
-                                                                ASSERT_EQUAL(ex.result, __ERRORRESULT, "Result in Error falsch");
 
                                                                 return resolve(true);
                                                             } catch (ex) {


### PR DESCRIPTION
codeLineFor(): Reaktion auf verschiedene ex-Typen, Verarbeitung von nicht-Firefox-Stacks
checkCodeLineBlacklist(): Korrektur mehrfache Verschachtelung
XHR.xmlRequest(): Nicht nur 'OK' ist okay, auch "", wenn Status 200 ist; __ONERROR()
assertionCatch(): codeLine() für error selbst, Bugfix __MATCH[2]
test.assert.test.js: __REJECTED lieferte 'uncaught', daher Funktion, auch __RESOLVED()
util.xhr.test.js: Bugfix: Alternative Fehlermeldung bei nicht-Firefox