### PR TITLE
Bugfixes und UnitTest: startMain()

### DIFF
--- a/misc/OS2/lib/util.store.js
+++ b/misc/OS2/lib/util.store.js
@@ -24,23 +24,45 @@ const __SCRIPTINIT = [];
 
 // Registrierung eine Startfunktion
 // startFun: Auszufuehrende Funktion
-// return void
+// return Promise auf void
 async function registerStartFun(startFun) {
     return __SCRIPTINIT.push(startFun);
 }
 
 // Funktion zum sequentiellen Aufruf der Startroutinen in __SCRIPTINIT ueber Promises
-// return Ein Promise-Objekt fuer den Programmstart
+// return Ein Promise-Objekt fuer den Programmstart (Inhalt: Anzahl der Startfunktionen)
 async function startMain() {
     return __SCRIPTINIT.Reduce((prom, fun) => prom.then(fun, defaultCatch),
-            Promise.resolve(true)).then(__SCRIPTINIT.length = 0);
+            Promise.resolve(true)).then(() => {
+                    const __LEN = __SCRIPTINIT.length;
+
+                    // Liste wurde korrekt verarbeitet, jetzt die Liste loeschen...
+                    __SCRIPTINIT.length = 0;
+
+                    // Liefert die Anzahl der verarbeiteten Startfunktionen...
+                    return __LEN;
+                }, defaultCatch);
+}
+
+// ==================== Abschnitt Meldung Schreibstatus ====================
+
+// Ausgabe auf die Konsole, ob __GMWRITE gesetzt ist (also Optionen beschreibbar sind)
+// return Promise auf void
+async function GM_showOptionsWritable() {
+    if (__GMWRITE) {
+        __LOG[8]("Schreiben von Optionen wurde AKTIVIERT!");
+    } else {
+        __LOG[8]("Schreiben von Optionen wurde DEAKTIVIERT!");
+    }
 }
 
 // ==================== Abschnitt Lesefilter und zugehoerigen Hilfsfunktionen ====================
 
-// Modifikationen fuer Kompatibilitaet (z.B. "undefined" statt undefined bei Tampermonkey)
+// Modifikationen fuer Kompatibilitaet (z.B. 'undefined' statt undefined bei Tampermonkey)
 const __GMREADFILTER = [];
 
+// Hilfsfunktion zur Ermittlung, ob der Tampermonkey-Bug vorliegt, dass undefined als 'undefined' gespeichert wird
+// return Angabe, ob der Tampermonkey-Bug vorliegt
 async function GM_checkForTampermonkeyBug() {
     const __TESTNAME = 'GM_checkForTampermonkeyBug';
     const __TESTVALUE = undefined;
@@ -105,7 +127,7 @@ async function GM_TampermonkeyFilter(value, name, defValue) {
     return value;
 }
 
-// ==================== Invarianter Abschnitt zur Speicherung (GM.setValue, GM.deleteValue) ====================
+// ==================== Abschnitt mit Hilfsroutine zur Kapselung von GM-Funktionen (GM.getValue, GM.setValue, GM.deleteValue, GM.listValues) ====================
 
 // Generator-Funktion: Liefert eine ausgewaehlte GM-Funktion
 // action: Name der Funktion im GM-Objekt
@@ -126,26 +148,23 @@ function GM_function(action, label, condition = true, altAction = undefined, lev
         };
 }
 
+// ==================== Abschnitt zur Kapselung von GM-Funktionen (GM.getValue, GM.setValue, GM.deleteValue, GM.listValues) und Start-Initialisierungen ====================
+
 // Umlenkung von Speicherung und Loeschung auf nicht-inversible 'getValue'-Funktion.
 // Falls __GMWRITE false ist, wird nicht geschrieben, bei true werden Optionen gespeichert.
-// TODO: Dynamische Variante
+// TODO: Dynamische Variante (bei Laufzeit umstellbar)
 const __GETVALUE = GM_function('getValue', 'GET');
 const __SETVALUE = GM_function('setValue', 'SET', __GMWRITE, 'getValue');
 const __DELETEVALUE = GM_function('deleteValue', 'DELETE', __GMWRITE, 'getValue');
 const __LISTVALUES = GM_function('listValues', 'KEYS');
 
-registerStartFun(async () => {
-        if (__GMWRITE) {
-            __LOG[8]("Schreiben von Optionen wurde AKTIVIERT!");
-        } else {
-            __LOG[8]("Schreiben von Optionen wurde DEAKTIVIERT!");
-        }
-    });
+// Anzeigen, ob Optionen beschreibbar sind (verzoegert)...
+registerStartFun(GM_showOptionsWritable);
 
-// GGfs. GM_TampermonkeyFilter aktivieren...
+// GGfs. GM_TampermonkeyFilter aktivieren (verzoegert)...
 registerStartFun(GM_checkForTampermonkeyBug);
 
-// ==================== Ende Invarianter Abschnitt zur Speicherung (GM.setValue, GM.deleteValue) ====================
+// ==================== Ende Abschnitt zur Kapselung von GM-Funktionen (GM.getValue, GM.setValue, GM.deleteValue, GM.listValues) und Start-Initialisierungen ====================
 
 // ==================== Abschnitt fuer die Sicherung und das Laden von Daten ====================
 

--- a/misc/OS2/test/util.store.test.js
+++ b/misc/OS2/test/util.store.test.js
@@ -28,15 +28,19 @@
                                         return ASSERT_TRUE(__GMWRITE, "Schreiben von Daten nicht aktiviert");
                                     },
             '__SCRIPTINIT'        : async function() {
+                                        __SCRIPTINIT.length = 0;  // Starterliste leeren...
+
                                         return callPromiseChain(startMain(), value => {
                                                 const __RET = value;
 
-                                                ASSERT_ZERO(__RET, "startMain() lieferte falschen R\xFCckgabewert");
+                                                ASSERT_ZERO(__RET, "startMain() darf keinen Eintrag verarbeiten");
 
                                                 return ASSERT_ZERO(__SCRIPTINIT.length, "__SCRIPTINIT ist nicht leer! Eventuell startMain() nicht ausgef\xFChrt?");
                                             }).catch(startMain);
                                     },
             'registerStartFun'    : async function() {
+                                        __SCRIPTINIT.length = 0;  // Starterliste leeren...
+
                                         return callPromiseChain(registerStartFun(() => undefined), value => {
                                                 const __RET = value;
 
@@ -46,24 +50,93 @@
                                             }, startMain, value => {
                                                 const __RET = value;
 
-                                                ASSERT_ZERO(__RET, "startMain() lieferte falschen R\xFCckgabewert");
+                                                ASSERT_ONE(__RET, "startMain() muss genau einen Eintrag verarbeiten");
 
                                                 return ASSERT_ZERO(__SCRIPTINIT.length, "__SCRIPTINIT ist nicht leer!");
                                             }).catch(startMain);
                                     },
+            'GM_WRITE'            : function() {
+                                        __SCRIPTINIT.length = 0;  // Starterliste leeren...
+
+                                        return callPromiseChain(registerStartFun(GM_showOptionsWritable), value => {
+                                                const __RET = value;
+
+                                                ASSERT_ONE(__RET, "registerStartFun() lieferte falschen R\xFCckgabewert");
+
+                                                return ASSERT_ONE(__SCRIPTINIT.length, "__SCRIPTINIT muss genau einen Eintrag haben");
+                                            }, startMain, value => {
+                                                const __RET = value;
+
+                                                ASSERT_ONE(__RET, "startMain() muss genau einen Eintrag verarbeiten");
+
+                                                return ASSERT_ZERO(__SCRIPTINIT.length, "__SCRIPTINIT ist nicht leer!");
+                                            });
+                                    },
+            'GM_checkTMbug'       : function() {
+                                        __SCRIPTINIT.length = 0;  // Starterliste leeren...
+
+                                        return callPromiseChain(registerStartFun(GM_checkForTampermonkeyBug), value => {
+                                                const __RET = value;
+
+                                                ASSERT_ONE(__RET, "registerStartFun() lieferte falschen R\xFCckgabewert");
+
+                                                return ASSERT_ONE(__SCRIPTINIT.length, "__SCRIPTINIT muss genau einen Eintrag haben");
+                                            }, startMain, value => {
+                                                const __RET = value;
+
+                                                ASSERT_ONE(__RET, "startMain() muss genau einen Eintrag verarbeiten");
+
+                                                return ASSERT_ZERO(__SCRIPTINIT.length, "__SCRIPTINIT ist nicht leer!");
+                                            });
+                                    },
             'startMain'           : function() {
+                                        __SCRIPTINIT.length = 0;  // Starterliste leeren...
+
                                         return callPromiseChain(registerStartFun(value => {
                                                 const __RET = value;
 
                                                 ASSERT_TRUE(__RET, "startMain() muss mit true starten");
 
-                                                // TODO ASSERT_ONE(__SCRIPTINIT.length, "__SCRIPTINIT muss genau einen Eintrag haben");
-
                                                 return 42;
-                                            }), startMain, value => {
+                                            }), value => {
                                                 const __RET = value;
 
-                                                ASSERT_EQUAL(__RET, 42, "startMain() lieferte falschen R\xFCckgabewert");
+                                                ASSERT_ONE(__RET, "registerStartFun() lieferte falschen R\xFCckgabewert");
+
+                                                return ASSERT_ONE(__SCRIPTINIT.length, "__SCRIPTINIT muss genau einen Eintrag haben");
+                                            }, startMain, value => {
+                                                const __RET = value;
+
+                                                ASSERT_ONE(__RET, "startMain() muss genau einen Eintrag verarbeiten");
+
+                                                return ASSERT_ZERO(__SCRIPTINIT.length, "__SCRIPTINIT ist nicht leer!");
+                                            });
+                                    },
+            'startMainAll'        : function() {
+                                        __SCRIPTINIT.length = 0;  // Starterliste leeren...
+
+                                        return callPromiseChain(
+                                            registerStartFun(GM_showOptionsWritable),
+                                            value => {
+                                                const __RET = value;
+
+                                                ASSERT_ONE(__RET, "registerStartFun() lieferte falschen R\xFCckgabewert");
+
+                                                return ASSERT_ONE(__SCRIPTINIT.length, "__SCRIPTINIT muss genau einen Eintrag haben");
+                                            },
+                                            () => registerStartFun(GM_checkForTampermonkeyBug),
+                                            value => {
+                                                const __RET = value;
+
+                                                ASSERT_EQUAL(__RET, 2, "registerStartFun() lieferte falschen R\xFCckgabewert");
+
+                                                ASSERT_EQUAL(__SCRIPTINIT.length, 2, "__SCRIPTINIT muss genau zwei Eintr\xE4ge haben");
+                                            },
+                                            startMain,
+                                            value => {
+                                                const __RET = value;
+
+                                                ASSERT_EQUAL(__RET, 2, "startMain() muss genau zwei Eintr\xE4ge verarbeiten");
 
                                                 return ASSERT_ZERO(__SCRIPTINIT.length, "__SCRIPTINIT ist nicht leer!");
                                             });


### PR DESCRIPTION
startMain(): Zusätzliches catch() und Rückgabewert
GM_showOptionsWritable() - Funktion statt inline
UnitTest 'util.store.js Basis': Liste leeren bei Tests mit Starterliste
außerdem 3 neue Tests GM_WRITE, GM_checkTMbug, startMainAll

