### PR TITLE
OS2.team.js: Bugfix OS2.tabelle: Verein.ID

### DIFF
--- a/misc/OS2/lib/OS2.team.js
+++ b/misc/OS2/lib/OS2.team.js
@@ -99,6 +99,15 @@ Class.define(Team, Object, {
 
         this.Manager = manager;
         this.Flags = (flags || []);
+
+        Object.defineProperty(this, 'ID', {
+                enumerable    : false,
+                configurable  : true,
+                get           : function() {
+                                    return this.TmNr;
+                                },
+                set           : undefined
+            });
     }
 //}
 


### PR DESCRIPTION
Verein.ID - Readonly Zugriff auf Verein.TmNr (aus Klasse Team)
Diese Verein.ID wird in OS2.tabelle eifrig genutzt

