### PR TITLE
Grundsätzliche Bereinigung der vorhandenen Unit-Tests

### DIFF
--- a/misc/OS2/OS2.tabelle.user.js
+++ b/misc/OS2/OS2.tabelle.user.js
@@ -1445,14 +1445,7 @@ console.log(__LTITEL);
 // Callback-Funktion fuer die Behandlung der Optionen und Laden des Benutzermenus
 // Diese Funktion erledigt nur Modifikationen und kann z.B. einfach optSet zurueckgeben!
 // optSet: Platz fuer die gesetzten Optionen
-// optParams: Eventuell notwendige Parameter zur Initialisierung
-// 'hideMenu': Optionen werden zwar geladen und genutzt, tauchen aber nicht im Benutzermenu auf
-// 'teamParams': Getrennte Daten-Option wird genutzt, hier: Team() mit 'LdNr'/'LgNr' des Erst- bzw. Zweitteams
-// 'menuAnchor': Startpunkt fuer das Optionsmenu auf der Seite
-// 'showForm': Checkliste der auf der Seite sichtbaren Optionen (true fuer sichtbar)
-// 'hideForm': Checkliste der auf der Seite unsichtbaren Optionen (true fuer unsichtbar)
-// 'formWidth': Anzahl der Elemente pro Zeile
-// 'formBreak': Elementnummer des ersten Zeilenumbruchs
+// optParams: Eventuell notwendige Parameter zur Initialisierung (unbenutzt!)
 // return Gefuelltes Objekt mit den gesetzten Optionen
 function prepareOptions(optSet, optParams) {
     UNUSED(optParams);

--- a/misc/OS2/index.html
+++ b/misc/OS2/index.html
@@ -238,7 +238,7 @@
 // @name         OS2.fssturnier
 // @namespace    http://os.ongapo.com/
 // @version      0.10+lib
-// @copyright    2017
+// @copyright    2017+
 // @author       Sven Loges (SLC)
 // @description  Script zum offiziellen FSS-Turnier fuer Online Soccer 2.0
 // @include      /^https?://(www\.)?(os\.ongapo\.com|online-soccer\.eu|os-zeitungen\.com)/haupt\.php(\?changetosecond=\w+(&\w+=?[+\w]+)*)?(#\w+)?$/

--- a/misc/OS2/test/index.html
+++ b/misc/OS2/test/index.html
@@ -187,6 +187,14 @@ const GM_info = {  // Mock GM_info data
     // Unit-Test-Ausfuehrung nur nach Klick!
     const __RET = true;
 
+    addEventListener("DOMContentLoaded", function() {
+            if (typeof (GM || { }).log === 'undefined') {  // Fehler beim Laden von 'gm4-polyfill.js'...
+                const __ANCHOR = document.querySelector("#run-unittests");
+
+                __ANCHOR.textContent = "Error loading 'gm4-polyfill.js'...";
+            }
+        });
+
     return __RET;
 })();
 

--- a/misc/OS2/test/test.class.unittest.test.js
+++ b/misc/OS2/test/test.class.unittest.test.js
@@ -32,13 +32,13 @@
 // ==================== Abschnitt fuer Klasse UnitTest ====================
 
     const __TESTDATA = {
-            'loadOption'    : [ "saison",   42,         18,             false,  undefined   ],
+            'loadOption'    : [ "saison",   42,         19,             false,  undefined   ],
         };
 
     new UnitTest('test.class.unittest.js', "Klasse UnitTest", {
-            'loadOption'          : function() {
-                                        
-                                    }
+//            'loadOption'          : function() {
+//                                        
+//                                    }
         });
 
 //function UnitTest(name, desc, tests, load) {

--- a/misc/OS2/test/test.lib.option.test.js
+++ b/misc/OS2/test/test.lib.option.test.js
@@ -27,13 +27,13 @@
 // ==================== Abschnitt fuer Klasse UnitTestOption ====================
 
     const __TESTDATA = {
-            'loadOption'    : [ "saison",   42,         18,             false,  undefined   ],
+            'loadOption'    : [ "saison",   42,         19,             false,  undefined   ],
         };
 
     new UnitTest('test.lib.option.js', "Klasse UnitTestOption", {
-            'loadOption'          : function() {
-                                        
-                                    }
+//            'loadOption'          : function() {
+//                                        
+//                                    }
         });
 
 //function UnitTestOption(name, desc, tests, load) {

--- a/misc/OS2/test/test.mock.gm.test.js
+++ b/misc/OS2/test/test.mock.gm.test.js
@@ -26,13 +26,13 @@
 // ==================== Abschnitt fuer Mock GM3-Funktionen ====================
 
     const __TESTDATA = {
-            'loadOption'    : [ "saison",   42,         18,             false,  undefined   ],
+            'loadOption'    : [ "saison",   42,         19,             false,  undefined   ],
         };
 
     new UnitTest('test.mock.gm.js', "Mock GM3-Funktionen", {
-            'loadOption'          : function() {
-                                        
-                                    }
+//            'loadOption'          : function() {
+//                                        
+//                                    }
         });
 
 //this.GM_getValue = function(name, defaultValue) {  // Mock GM_getValue function

--- a/misc/OS2/test/util.debug.test.js
+++ b/misc/OS2/test/util.debug.test.js
@@ -25,13 +25,13 @@
 // ==================== Abschnitt fuer Debugging und Error-Handling ====================
 
     const __TESTDATA = {
-            'loadOption'    : [ "saison",   42,         18,             false,  undefined   ],
+            'loadOption'    : [ "saison",   42,         19,             false,  undefined   ],
         };
 
     new UnitTest('util.debug.js', "Utilities zu Debugging und Error-Handling", {
-            'loadOption'          : function() {
-                                        
-                                    }
+//            'loadOption'          : function() {
+//                                        
+//                                    }
         });
 
 //function showAlert(label, message, data = undefined, show = true) {

--- a/misc/OS2/test/util.object.test.js
+++ b/misc/OS2/test/util.object.test.js
@@ -27,13 +27,13 @@
 // ==================== Abschnitt fuer detaillierte Ausgabe von Daten ====================
 
     const __TESTDATA = {
-            'loadOption'    : [ "saison",   42,         18,             false,  undefined   ],
+            'loadOption'    : [ "saison",   42,         19,             false,  undefined   ],
         };
 
     new UnitTest('util.object.js', "Utilities fuer Object, Array, etc.", {
-            'loadOption'          : function() {
-                                        
-                                    }
+//            'loadOption'          : function() {
+//                                        
+//                                    }
         });
 
 //Object.Map = function(obj, mapFun, thisArg, filterFun, sortFun) {

--- a/misc/OS2/test/util.option.api.test.js
+++ b/misc/OS2/test/util.option.api.test.js
@@ -29,7 +29,7 @@
     const __TESTDATA = {
             'prefixName'    : [ "Name",     "Prefix",   "PrefixName"                        ],
             'postfixName'   : [ "Name",     "Postfix",  "NamePostfix"                       ],
-            'loadOption'    : [ "saison",   42,         18,             false,  undefined   ]
+            'loadOption'    : [ "saison",   42,         19,             false,  undefined   ]
         };
 
     new UnitTestOption('util.option.api.js', "Schnittstelle zur Behandlung von Optionen", {

--- a/misc/OS2/test/util.xhr.gm.test.js
+++ b/misc/OS2/test/util.xhr.gm.test.js
@@ -62,6 +62,9 @@
             'browseXML'           : function() {
                                         const [ __URL, __EXP ] = __TESTDATA['browseXML'];
 
+                                        ASSERT_SET(__THIS.browse, __LABEL + "Methode 'browse' nicht gefunden");
+                                        ASSERT_TYPEOF(__THIS.browse, 'function', __LABEL + "Methode 'browse' ist keine Funktion");
+
                                         return callPromiseChain(__THIS.browse(__URL), doc => {
                                                 const __RET = doc;
 
@@ -70,6 +73,9 @@
                                     },
             'browseXMLonload'     : function() {
                                         const [ __URL, __EXP ] = __TESTDATA['browseXML'];
+
+                                        ASSERT_SET(__THIS.browse, __LABEL + "Methode 'browse' nicht gefunden");
+                                        ASSERT_TYPEOF(__THIS.browse, 'function', __LABEL + "Methode 'browse' ist keine Funktion");
 
                                         return new Promise(function(resolve, reject) {
                                                 return __THIS.browse(__URL, null, request => {
@@ -92,6 +98,9 @@
             'browseXMLCORS'       : function() {
                                         const [ __URL, __EXP ] = __TESTDATA['browseXMLCORS'];
 
+                                        ASSERT_SET(__THIS.browse, __LABEL + "Methode 'browse' nicht gefunden");
+                                        ASSERT_TYPEOF(__THIS.browse, 'function', __LABEL + "Methode 'browse' ist keine Funktion");
+
                                         return callPromiseChain(__THIS.browse(__URL), doc => {
                                                 const __RET = doc;
 
@@ -100,6 +109,9 @@
                                     },
             'browseXMLCORSonload' : function() {
                                         const [ __URL, __EXP ] = __TESTDATA['browseXMLCORS'];
+
+                                        ASSERT_SET(__THIS.browse, __LABEL + "Methode 'browse' nicht gefunden");
+                                        ASSERT_TYPEOF(__THIS.browse, 'function', __LABEL + "Methode 'browse' ist keine Funktion");
 
                                         return new Promise(function(resolve, reject) {
                                                 return __THIS.browse(__URL, null, request => {

--- a/misc/OS2/test/util.xhr.test.js
+++ b/misc/OS2/test/util.xhr.test.js
@@ -61,6 +61,9 @@
             'browseXML'           : function() {
                                         const [ __URL, __EXP ] = __TESTDATA['browseXML'];
 
+                                        ASSERT_SET(__THIS.browse, __LABEL + "Methode 'browse' nicht gefunden");
+                                        ASSERT_TYPEOF(__THIS.browse, 'function', __LABEL + "Methode 'browse' ist keine Funktion");
+
                                         return callPromiseChain(__THIS.browse(__URL), doc => {
                                                 const __RET = doc;
 
@@ -69,6 +72,9 @@
                                     },
             'browseXMLonload'     : function() {
                                         const [ __URL, __EXP ] = __TESTDATA['browseXML'];
+
+                                        ASSERT_SET(__THIS.browse, __LABEL + "Methode 'browse' nicht gefunden");
+                                        ASSERT_TYPEOF(__THIS.browse, 'function', __LABEL + "Methode 'browse' ist keine Funktion");
 
                                         return new Promise(function(resolve, reject) {
                                                 return __THIS.browse(__URL, null, request => {
@@ -95,6 +101,9 @@
                                         const __ERRORTYPE = 'NetworkError';
                                         const __ERRORRESULT = 2152923155;
 
+                                        ASSERT_SET(__THIS.browse, __LABEL + "Methode 'browse' nicht gefunden");
+                                        ASSERT_TYPEOF(__THIS.browse, 'function', __LABEL + "Methode 'browse' ist keine Funktion");
+
                                         return callPromiseChain(__THIS.browse(__URL), doc => {
                                                 const __RET = doc;
 
@@ -117,6 +126,9 @@
                                         const __ERRORMSG2 = "Failed to execute 'send' on 'XMLHttpRequest': Failed to load '" + __URL.replaceAll(' ', "%20") + "'.";
                                         const __ERRORTYPE = 'NetworkError';
                                         const __ERRORRESULT = 2152923155;
+
+                                        ASSERT_SET(__THIS.browse, __LABEL + "Methode 'browse' nicht gefunden");
+                                        ASSERT_TYPEOF(__THIS.browse, 'function', __LABEL + "Methode 'browse' ist keine Funktion");
 
                                         return new Promise(function(resolve, reject) {
                                                 return __THIS.browse(__URL, null, request => {


### PR DESCRIPTION
OS2.tabelle: Kommentar von prepareOptions() korrigiert test/index.html: Unit-Tests deaktivieren, falls GM4-Polyfill nicht geladen wurde
test/test.class.unittest, test/test.lib.option, test/test.mock.gm, test/util.debug, test/util.object: Dummy-Test entfernt test/util.option.api: Saison wurde auf 19 geändert, war im Test aber noch 18
test/util.xhr, test/util.xhr.gm: Statt Error lieber Fail durch Überprüfung von __THIS.browse

