### PR TITLE
Os2 unit test 70

### DIFF
--- a/misc/OS2/lib/index.html
+++ b/misc/OS2/lib/index.html
@@ -266,6 +266,7 @@ const __BUILDLIB = (async (libNumber) => {
             'test.class.unittest',
             'test.lib.option',
             'test.mock.gm',
+            'util.class.uri',
             'util.debug',
             'util.log',
             'util.object',

--- a/misc/OS2/lib/test.class.unittest.js
+++ b/misc/OS2/lib/test.class.unittest.js
@@ -222,7 +222,7 @@ UnitTest.runAll = async function(minLevel = 1, resultFun = UnitTest.defaultResul
             const __TFUN = __TEST['run'];      // TODO: __TEST.run, aber variabel gehalten!
             const __CFUN = __TEST['cleanup'];  // TODO: __TEST.cleanup, aber variabel gehalten!
             const __THIS = (thisArg || __TEST);
-            const __RESULTS = new UnitTestResults("SUMME", __NAME, __TEST);
+            const __RESULTS = new UnitTestResults("SUMME", __DESC, __TEST);
             let result;
 
             // Test initialisieren und zaehlen...
@@ -304,7 +304,7 @@ UnitTest.defaultResultFun = function(resultObj, tableId, doc = document) {
     const __STYLE = UnitTest.getStyleFromResults(__RESULTS);
     const __SHOW = (__STYLE.__RESULTCLASS >= __MINLEVEL);
     const __ENDSUMMARY = (__RESULTS.name == 'TOTAL');
-    const __SUMMARY = ((__UNITTEST.name === __RESULTS.desc) || __ENDSUMMARY);
+    const __SUMMARY = ((__UNITTEST.desc === __RESULTS.desc) || __ENDSUMMARY);
     const __SHOWRESULT = (__RESULTS.name && (__SHOW || __SUMMARY));
     const __CREATEROW = (__SHOWRESULT || (__MINLEVEL < 1));
 

--- a/misc/OS2/lib/util.class.uri.js
+++ b/misc/OS2/lib/util.class.uri.js
@@ -133,7 +133,7 @@ Class.define(URI, Path, {
 
                                          return ((~ __INDEXQUERY) ? path.substring(0, __INDEXQUERY) : path);
                                      },
-               'formatParams'      : function(params, formatFun, delim = ' ', assign = '=') {
+               'formatParams'      : function(params = [], formatFun = sameValue, delim = ' ', assign = '=') {
                                          const __PARAMS = [];
 
                                          for (let param in params) {

--- a/misc/OS2/test/index.html
+++ b/misc/OS2/test/index.html
@@ -87,6 +87,7 @@ const GM_info = {  // Mock GM_info data
         <SCRIPT type="text/javascript" defer src="https://eselce.github.io/GitTest/misc/OS2/test/test.class.unittest.test.js"></SCRIPT>
         <SCRIPT type="text/javascript" defer src="https://eselce.github.io/GitTest/misc/OS2/test/test.lib.option.test.js"></SCRIPT>
         <SCRIPT type="text/javascript" defer src="https://eselce.github.io/GitTest/misc/OS2/test/test.mock.gm.test.js"></SCRIPT>
+        <SCRIPT type="text/javascript" defer src="https://eselce.github.io/GitTest/misc/OS2/test/util.class.uri.test.js"></SCRIPT>
         <SCRIPT type="text/javascript" defer src="https://eselce.github.io/GitTest/misc/OS2/test/util.debug.test.js"></SCRIPT>
         <SCRIPT type="text/javascript" defer src="https://eselce.github.io/GitTest/misc/OS2/test/util.log.test.js"></SCRIPT>
         <SCRIPT type="text/javascript" defer src="https://eselce.github.io/GitTest/misc/OS2/test/util.object.test.js"></SCRIPT>
@@ -155,6 +156,7 @@ const GM_info = {  // Mock GM_info data
         <SCRIPT type="text/javascript" defer src="test.class.unittest.test.js"></SCRIPT>
         <SCRIPT type="text/javascript" defer src="test.lib.option.test.js"></SCRIPT>
         <SCRIPT type="text/javascript" defer src="test.mock.gm.test.js"></SCRIPT>
+        <SCRIPT type="text/javascript" defer src="util.class.uri.test.js"></SCRIPT>
         <SCRIPT type="text/javascript" defer src="util.debug.test.js"></SCRIPT>
         <SCRIPT type="text/javascript" defer src="util.log.test.js"></SCRIPT>
         <SCRIPT type="text/javascript" defer src="util.object.test.js"></SCRIPT>

--- a/misc/OS2/test/util.class.uri.test.js
+++ b/misc/OS2/test/util.class.uri.test.js
@@ -1,0 +1,107 @@
+// ==UserScript==
+// _name         util.class.uri.test
+// _namespace    http://os.ongapo.com/
+// _version      0.10
+// _copyright    2023+
+// _author       Sven Loges (SLC)
+// _description  Unit-Tests JS-lib mit Funktionen und Utilities fuer Details zu Objekten, Arrays, etc.
+// _require      https://eselce.github.io/OS2.scripts/lib/util.class.js
+// _require      https://eselce.github.io/OS2.scripts/lib/util.class.delim.js
+// _require      https://eselce.github.io/OS2.scripts/lib/util.class.path.js
+// _require      https://eselce.github.io/OS2.scripts/lib/util.class.uri.js
+// _require      https://eselce.github.io/OS2.scripts/lib/test.assert.js
+// _require      https://eselce.github.io/OS2.scripts/lib/test.class.unittest.js
+// _require      https://eselce.github.io/OS2.scripts/test/util.class.uri.test.js
+// ==/UserScript==
+
+// ECMAScript 6:
+/* jshint esnext: true */
+/* jshint moz: true */
+
+// ==================== Abschnitt fuer Unit-Tests zu util.class.uri ====================
+
+(() => {
+
+// ==================== Abschnitt fuer diverse Utilities fuer URLs etc. ====================
+
+    const __TESTDATA = {
+            'formatParamsUnform'    : [ { "saison" : 19, "ZAT" : 15 },  ' ',    '=',    "saison=19 ZAT=15",         'string'    ],
+            'formatParamsString'    : [ { "saison" : 19, "ZAT" : 15 },  ' ',    '=',    'saison="19" ZAT="15"',     'string'    ],
+            'formatParamsObjForm'   : [ { "saison" : 19, "ZAT" : 15 },  ', ',   ' : ',  "saison : 19, ZAT : 15",    'string'    ],
+            'formatParamsEmpty'     : [ null,                           ' ',    '=',    "",                         'string'    ],
+        };
+
+    new UnitTest('util.class.uri.js', "Klasse URI fuer URLs etc.", {
+//               'setDelims'         : function() {
+//               'setSchemeDelim'    : function(schemeDelim = undefined) {
+//               'setQueryDelim'     : function(queryDelim = undefined) {
+//               'setParSepDelim'    : function(parSepDelim = undefined) {
+//               'setParAssDelim'    : function(parAssDelim = undefined) {
+//               'setNodeDelim'      : function(nodeDelim = undefined) {
+//               'getServerPath'     : function(path = undefined) {
+//               'getHostPort'       : function(path = undefined) {
+//               'stripHostPort'     : function(path = undefined) {
+//               'getSchemePrefix'   : function(path = undefined) {
+//               'stripSchemePrefix' : function(path = undefined) {
+//               'getNodeSuffix'     : function(path = undefined) {
+//               'stripNodeSuffix'   : function(path = undefined) {
+//               'getQueryString'    : function(path = undefined) {
+//               'stripQueryString'  : function(path = undefined) {
+
+            'formatParamsUnform'              : function() {
+                                                    const [ __VAL, __DLM, __ASS, __EXP, __TYPE ] = __TESTDATA['formatParamsUnform'];
+                                                    const __FORMATFUN = undefined;
+                                                    const __RET = URI.prototype.formatParams(__VAL, __FORMATFUN, __DLM, __ASS);
+
+                                                    ASSERT_EQUAL(__RET, __EXP, "formatParams() muss String zur\u00FCckgeben");
+
+                                                    return ASSERT_TYPEOF(__RET, __TYPE, "formatParams() muss String zur\u00FCckgeben");
+                                                },
+            'formatParamsString'              : function() {
+                                                    const [ __VAL, __DLM, __ASS, __EXP, __TYPE ] = __TESTDATA['formatParamsString'];
+                                                    const __FORMATFUN = function(value) {
+                                                                            return '"' + value + '"';
+                                                                        };
+                                                    const __RET = URI.prototype.formatParams(__VAL, __FORMATFUN, __DLM, __ASS);
+
+                                                    ASSERT_EQUAL(__RET, __EXP, "formatParams() muss String zur\u00FCckgeben");
+
+                                                    return ASSERT_TYPEOF(__RET, __TYPE, "formatParams() muss String zur\u00FCckgeben");
+                                                },
+            'formatParamsObjForm'             : function() {
+                                                    const [ __VAL, __DLM, __ASS, __EXP, __TYPE ] = __TESTDATA['formatParamsObjForm'];
+                                                    const __FORMATFUN = sameValue;
+                                                    const __RET = URI.prototype.formatParams(__VAL, __FORMATFUN, __DLM, __ASS);
+
+                                                    ASSERT_EQUAL(__RET, __EXP, "formatParams() muss String zur\u00FCckgeben");
+
+                                                    return ASSERT_TYPEOF(__RET, __TYPE, "formatParams() muss String zur\u00FCckgeben");
+                                                },
+            'formatParamsEmpty'               : function() {
+                                                    const [ __VAL, __DLM, __ASS, __EXP, __TYPE ] = __TESTDATA['formatParamsEmpty'];
+                                                    const __FORMATFUN = sameValue;
+                                                    const __RET = URI.prototype.formatParams(__VAL, __FORMATFUN, __DLM, __ASS);
+
+                                                    ASSERT_EQUAL(__RET, __EXP, "formatParams() muss String zur\u00FCckgeben");
+
+                                                    return ASSERT_TYPEOF(__RET, __TYPE, "formatParams() muss String zur\u00FCckgeben");
+                                                },
+
+//               'parseParams'       : function(params, parseFun, delim = ' ', assign = '=') {
+//               'rawValue'          : function(value) {
+//               'parseValue'        : function(value) {
+//               'getQuery'          : function(delims = { }) {
+//               'parseQuery'        : function(path = undefined, delims = { }) {
+//               'setQuery'          : function(query) {
+//               'setQueryPar'       : function(key, value) {
+//               'getPath'           : function(dirs = undefined, delims = undefined) {
+//               'getDirs'           : function(path = undefined, delims) {
+        });
+
+// ==================== Ende Abschnitt fuer diverse Utilities fuer URLs etc. ====================
+
+})();
+
+// ==================== Ende Abschnitt fuer Unit-Tests zu util.class.uri ====================
+
+// *** EOF ***


### PR DESCRIPTION
util.class.uri: formatParams() ohne formatFun (bzw. ohne params)
util.class.uri.test: Unit-Tests für Klasse URI (formatParams())
test.class.unittest: Desc statt Name in Details-Spalte