### PR TITLE
YTsearch Adaption2

### DIFF
--- a/misc/OS2/lib/util.value.js
+++ b/misc/OS2/lib/util.value.js
@@ -278,56 +278,109 @@ function getNumberString(numberString) {
 
 // Gibt ein Array als String zurueck.
 // arr: Das auszugebende Array
-// space: whitespace delimiter for array output (Default: ' ')
+// spaceOrFormat: Entweder ein Format-Object mit Angaben zur Ausgabe
+//                oder Trenner fuer Array-Ausgabe (Default: ' ')
+// - space: Trenner fuer Array-Ausgabe (Default: ' ')
+// - delim: Trenner zwischen Elementen (Default: ',')
+// - pre: Startklammer (Default: '[')
+// - post: Endklammer (Default: ']')
+// - mapFun: map()-Operation, die auf Elemente angewandt wird
+// - mark: Trenner fuer Markierungen (Default: '*')
+// - markEnd: Trenner fuer Ende der Markierung, falls anders (Default: mark)
+// - markIndex: Index des zu markierenden Elements
+// - markFun: Identifizierung von Elementen, die markiert werden (Default: markIndex)
 // return String mit allen Werten des Arrays
-function getArrString(arr, space = ' ') {
+function getArrString(arr, spaceOrFormat = ' ') {
     const __ARR = arr;
-    const __SPACE = space;
-    const __PRE = '[' + __SPACE;
-    const __MID = ',' + __SPACE;
-    const __POST = __SPACE + ']';
-    const __ARRSTR = __ARR.join(__MID);
+    const __FORMAT = (((typeof spaceOrFormat) === 'string') ? { 'space': spaceOrFormat }
+                    : (((typeof spaceOrFormat) === 'number') ? { 'markIndex': spaceOrFormat }
+                    : spaceOrFormat));
+    const __SPACE = getValue(__FORMAT.space, ' ');
+    const __PRE = getValue(__FORMAT.pre, '[') + __SPACE;
+    const __MID = getValue(__FORMAT.delim, ',') + __SPACE;
+    const __POST = __SPACE + getValue(__FORMAT.post, ']');
+    const __MAPFUN = (__FORMAT.mapFun, sameValue);
+    const __MARK = getValue(__FORMAT.mark, '*');
+    const __MARKEND = getValue(__FORMAT.markEnd, __MARK);
+    const __MARKINDEX = getValue(__FORMAT.markIndex, -1);
+    const __MARKFUN = (__FORMAT.markFun || ((elem, index) => (index == __MARKINDEX)));
+    const __DOMARKFUN = ((elem, index, arr) => (__MARKFUN(elem, index, arr) ? (__MARK + elem + __MARKEND) : elem));
+    const __MAPPEDARR = __ARR.map(__MAPFUN);
+    const __MARKEDARR = __MAPPEDARR.map(__DOMARKFUN);
+    const __ARRSTR = __MARKEDARR.join(__MID);
 
     return (__PRE + __ARRSTR + __POST);
 }
 
 // Gibt die Keys eines Objects als String zurueck.
 // obj: Das auszugebende Object
-// space: whitespace delimiter for array output (Default: ' ')
+// spaceOrFormat: Entweder ein Format-Object mit Angaben zur Ausgabe
+//                oder Trenner fuer Array-Ausgabe (Default: ' ')
+// - space: Trenner fuer Array-Ausgabe (Default: ' ')
+// - delim: Trenner zwischen Elementen (Default: ',')
+// - pre: Startklammer (Default: '[')
+// - post: Endklammer (Default: ']')
+// - mapFun: map()-Operation, die auf Elemente angewandt wird
+// - mark: Trenner fuer Markierungen (Default: '*')
+// - markEnd: Trenner fuer Ende der Markierung, falls anders (Default: mark)
+// - markIndex: Index des zu markierenden Elements
+// - markFun: Identifizierung von Elementen, die markiert werden (Default: markIndex)
 // return String mit allen Keys
-function getKeyString(obj, space = ' ') {
+function getKeyString(obj, spaceOrFormat = ' ') {
     const __OBJ = obj;
-    const __SPACE = space;
+    const __FORMAT = spaceOrFormat;
     const __KEYS = Object.keys(__OBJ);
-    const __KEYSTR = getArrString(__KEYS, __SPACE);
+    const __KEYSTR = getArrString(__KEYS, __FORMAT);
 
     return __KEYSTR;
 }
 
 // Gibt die Werte eines Objects als String zurueck.
 // obj: Das auszugebende Object
-// space: whitespace delimiter for array output (Default: ' ')
+// spaceOrFormat: Entweder ein Format-Object mit Angaben zur Ausgabe
+//                oder Trenner fuer Array-Ausgabe (Default: ' ')
+// - space: Trenner fuer Array-Ausgabe (Default: ' ')
+// - delim: Trenner zwischen Elementen (Default: ',')
+// - pre: Startklammer (Default: '[')
+// - post: Endklammer (Default: ']')
+// - mapFun: map()-Operation, die auf Elemente angewandt wird
+// - mark: Trenner fuer Markierungen (Default: '*')
+// - markEnd: Trenner fuer Ende der Markierung, falls anders (Default: mark)
+// - markIndex: Index des zu markierenden Elements
+// - markFun: Identifizierung von Elementen, die markiert werden (Default: markIndex)
 // return String mit allen Werten
-function getValueString(obj, space = ' ') {
+function getValueString(obj, spaceOrFormat = ' ') {
     const __OBJ = obj;
-    const __SPACE = space;
+    const __FORMAT = spaceOrFormat;
     const __VALUES = Object.values(__OBJ);
-    const __VALUESTR = getArrString(__VALUES, __SPACE);
+    const __VALUESTR = getArrString(__VALUES, __FORMAT);
 
     return __VALUESTR;
 }
 
 // Gibt die Entries eines Objects als String zurueck.
 // obj: Das auszugebende Object
-// space: whitespace delimiter for array output (Default: ' ')
+// spaceOrFormat: Entweder ein Format-Object mit Angaben zur Ausgabe
+//                oder Trenner fuer Array-Ausgabe (Default: ' ')
+// - space: Trenner fuer Array-Ausgabe (Default: ' ')
+// - delim: Trenner zwischen Elementen (Default: ',')
+// - pre: Startklammer (Default: '[')
+// - post: Endklammer (Default: ']')
+// - mapFun: map()-Operation, die auf Elemente angewandt wird
+// - mark: Trenner fuer Markierungen (Default: '*')
+// - markEnd: Trenner fuer Ende der Markierung, falls anders (Default: mark)
+// - markIndex: Index des zu markierenden Elements
+// - markFun: Identifizierung von Elementen, die markiert werden (Default: markIndex)
+// mapFun: ([key, value]) => Verarbeitung der Eintraege zu Elementen
 // return String mit allen Entries
-function getEntryString(obj, space = ' ', mapFun = undefined) {
+function getEntryString(obj, spaceOrFormat = ' ', mapFun = undefined) {
     const __OBJ = obj;
-    const __SPACE = space;
+    const __FORMAT = spaceOrFormat;
+    const __SPACE = getValue(__FORMAT.space, ' ');
     const __MAPFUN = (mapFun || (([key, value]) => ("'" + key + "':" + __SPACE + value)));
     const __ENTRIES = Object.entries(__OBJ);
     const __MAPPEDENTRIES = __ENTRIES.map(__MAPFUN);
-    const __ENTRYSTR = getArrString(__MAPPEDENTRIES, __SPACE);
+    const __ENTRYSTR = getArrString(__MAPPEDENTRIES, __FORMAT);
 
     return __ENTRYSTR;
 }

--- a/misc/OS2/lib/util.value.js
+++ b/misc/OS2/lib/util.value.js
@@ -291,10 +291,10 @@ function getNumberString(numberString) {
 // - markFun: Identifizierung von Elementen, die markiert werden (Default: markIndex)
 // return String mit allen Werten des Arrays
 function getArrString(arr, spaceOrFormat = ' ') {
-    const __ARR = arr;
+    const __ARR = getValue(arr, []);
     const __FORMAT = (((typeof spaceOrFormat) === 'string') ? { 'space': spaceOrFormat }
                     : (((typeof spaceOrFormat) === 'number') ? { 'markIndex': spaceOrFormat }
-                    : spaceOrFormat));
+                    : getValue(spaceOrFormat, { })));
     const __SPACE = getValue(__FORMAT.space, ' ');
     const __PRE = getValue(__FORMAT.pre, '[') + __SPACE;
     const __MID = getValue(__FORMAT.delim, ',') + __SPACE;
@@ -327,7 +327,7 @@ function getArrString(arr, spaceOrFormat = ' ') {
 // - markFun: Identifizierung von Elementen, die markiert werden (Default: markIndex)
 // return String mit allen Keys
 function getKeyString(obj, spaceOrFormat = ' ') {
-    const __OBJ = obj;
+    const __OBJ = getValue(obj, { });
     const __FORMAT = spaceOrFormat;
     const __KEYS = Object.keys(__OBJ);
     const __KEYSTR = getArrString(__KEYS, __FORMAT);
@@ -350,7 +350,7 @@ function getKeyString(obj, spaceOrFormat = ' ') {
 // - markFun: Identifizierung von Elementen, die markiert werden (Default: markIndex)
 // return String mit allen Werten
 function getValueString(obj, spaceOrFormat = ' ') {
-    const __OBJ = obj;
+    const __OBJ = getValue(obj, { });
     const __FORMAT = spaceOrFormat;
     const __VALUES = Object.values(__OBJ);
     const __VALUESTR = getArrString(__VALUES, __FORMAT);
@@ -371,15 +371,15 @@ function getValueString(obj, spaceOrFormat = ' ') {
 // - markEnd: Trenner fuer Ende der Markierung, falls anders (Default: mark)
 // - markIndex: Index des zu markierenden Elements
 // - markFun: Identifizierung von Elementen, die markiert werden (Default: markIndex)
-// mapFun: ([key, value]) => Verarbeitung der Eintraege zu Elementen
+// entryFun: ([key, value]) => Verarbeitung der Eintraege zu Elementen
 // return String mit allen Entries
-function getEntryString(obj, spaceOrFormat = ' ', mapFun = undefined) {
-    const __OBJ = obj;
-    const __FORMAT = spaceOrFormat;
+function getEntryString(obj, spaceOrFormat = ' ', entryFun = undefined) {
+    const __OBJ = getValue(obj, { });
+    const __FORMAT = getValue(spaceOrFormat, { });
     const __SPACE = getValue(__FORMAT.space, ' ');
-    const __MAPFUN = (mapFun || (([key, value]) => ("'" + key + "':" + __SPACE + value)));
+    const __ENTRYFUN = (entryFun || (([key, value]) => ("'" + key + "':" + __SPACE + value)));
     const __ENTRIES = Object.entries(__OBJ);
-    const __MAPPEDENTRIES = __ENTRIES.map(__MAPFUN);
+    const __MAPPEDENTRIES = __ENTRIES.map(__ENTRYFUN);
     const __ENTRYSTR = getArrString(__MAPPEDENTRIES, __FORMAT);
 
     return __ENTRYSTR;

--- a/misc/OS2/test/util.value.test.js
+++ b/misc/OS2/test/util.value.test.js
@@ -949,10 +949,10 @@
 //function getOrdinal(value, defValue = '*') {
 //+function getNumber(numberString) {
 //function getNumberString(numberString) {
-//function getArrString(arr, space = ' ') {
-//function getKeyString(obj, space = ' ') {
-//function getValueString(obj, space = ' ') {
-//function getEntryString(obj, space = ' ', mapFun = undefined) {
+//function getArrString(arr, spaceOrFormat = ' ') {
+//function getKeyString(obj, spaceOrFormat = ' ') {
+//function getValueString(obj, spaceOrFormat = ' ') {
+//function getEntryString(obj, spaceOrFormat = ' ', entryFun = undefined) {
 //function floorValue(value, dot = '.') {
 //function toArray(value) {
 //function flatArray(... args) {


### PR DESCRIPTION
[util.value: get(Arr|Key|Value|Entry)String(): spaceOrFormat Erweiterung]

getArrString(), getKeyString(), getValueString(), getEntryString():
Parameter spaceOrFormat statt space - Komplexe Handhabung mit Angaben:
- space (die vorherige Funktion, wird weiterhin als String erfüllt)
- delim: Trenner zwischen den Elementen ','
- pre: Start '['
- post: Ende ']'
- mapFun: Element-Map
- mark: Markierung '*' für '*<elem>*'
- markEnd: Asymmetrische Markierung (alternatives Ende)
- markIndex: Index der Markierung (für Default-MarkFun)
- markFun: Identifiziert zu markierende Elemente

Bisher wurde von sortFun und filterFun abgesehen, um es relativ einfach
zu halten. Man kann sortieren und filtern, bevor man dies aufruft.